### PR TITLE
feat(client): add new hook useCurrentUser

### DIFF
--- a/samples/sample-action-button-dropdown-plugin/src/sample-action-button-dropdown-plugin-item/component.tsx
+++ b/samples/sample-action-button-dropdown-plugin/src/sample-action-button-dropdown-plugin-item/component.tsx
@@ -10,6 +10,7 @@ function SampleActionButtonDropdownPlugin({ pluginUuid: uuid }: SampleActionButt
   const [showModal, setShowModal] = useState<boolean>(false);
   const pluginApi: BbbPluginSdk.PluginApi = BbbPluginSdk.getPluginApi(uuid);
   const [currentSlideText, setCurrentSlideText] = useState<string>('');
+  const currentUser = BbbPluginSdk.useCurrentUser();
 
   const currentPresentation = BbbPluginSdk.useCurrentPresentation();
 
@@ -34,20 +35,22 @@ function SampleActionButtonDropdownPlugin({ pluginUuid: uuid }: SampleActionButt
     setShowModal(false);
   };
 
-  useEffect(() => {    
-    pluginApi.setActionButtonDropdownItems([
-      new BbbPluginSdk.ActionButtonDropdownSeparator(),
-      new BbbPluginSdk.ActionButtonDropdownOption({
-        label: 'Fetch presentation content',
-        icon: 'copy',
-        tooltip: 'this is a button injected by plugin',
-        allowed: true,
-        onClick: () => {
-          handleFetchPresentationData(currentPresentation);
-        },
-      }),
-    ]);
-  }, [currentPresentation]);
+  useEffect(() => {
+    if (currentUser?.presenter){
+      pluginApi.setActionButtonDropdownItems([
+        new BbbPluginSdk.ActionButtonDropdownSeparator(),
+        new BbbPluginSdk.ActionButtonDropdownOption({
+          label: 'Fetch presentation content',
+          icon: 'copy',
+          tooltip: 'this is a button injected by plugin',
+          allowed: true,
+          onClick: () => {
+            handleFetchPresentationData(currentPresentation);
+          },
+        }),
+      ]);
+    }
+  }, [currentPresentation, currentUser]);
 
   return (
     <ReactModal

--- a/src/data-consumption/hooks/index.ts
+++ b/src/data-consumption/hooks/index.ts
@@ -1,2 +1,2 @@
-export { default as useCurrentPresentation } from './presentation';
-export { default as useLoadedUserList } from './user';
+export * from './presentation';
+export * from './user';

--- a/src/data-consumption/hooks/presentation.ts
+++ b/src/data-consumption/hooks/presentation.ts
@@ -30,4 +30,6 @@ const useCurrentPresentation: () => CurrentPresentation | undefined = () => {
   return presentationInfo;
 };
 
-export default useCurrentPresentation;
+export {
+  useCurrentPresentation,
+};

--- a/src/data-consumption/hooks/user.ts
+++ b/src/data-consumption/hooks/user.ts
@@ -30,4 +30,34 @@ const useLoadedUserList: () => User[] | undefined = () => {
   return userInfo;
 };
 
-export default useLoadedUserList;
+const useCurrentUser: () => User | undefined = () => {
+  const [userInfo, setUserInfo] = useState<User | undefined>();
+  const handleCurrentUserUpdateEvent: EventListener = (
+    (event: CustomEventHookWrapper<User>) => {
+      if (event.detail.hook === Internal.BbbHooks.UseCurrentUser) {
+        setUserInfo(event.detail.data);
+      }
+    }) as EventListener;
+  useEffect(() => {
+    window.addEventListener(Internal.BbbHookEvents.Update, handleCurrentUserUpdateEvent);
+    window.dispatchEvent(new CustomEvent(Internal.BbbHookEvents.Subscribe, {
+      detail: { hook: Internal.BbbHooks.UseCurrentUser },
+    }));
+    return () => {
+      window.dispatchEvent(new CustomEvent(Internal.BbbHookEvents.Unsubscribe, {
+        detail: { hook: Internal.BbbHooks.UseCurrentUser },
+      }));
+      window.removeEventListener(
+        Internal.BbbHookEvents.Update,
+        handleCurrentUserUpdateEvent,
+      );
+    };
+  }, []);
+
+  return userInfo;
+};
+
+export {
+  useLoadedUserList,
+  useCurrentUser,
+};

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -7,6 +7,7 @@ enum BbbHookEvents {
 enum BbbHooks {
   UseCurrentPresentation = 'BbbHooks::UseCurrentPresentation',
   UseLoadedUserList = 'BbbHooks::UseLoadedUserList',
+  UseCurrentUser = 'BbbHooks::UseCurrentUser'
 }
 
 export const Internal = {


### PR DESCRIPTION
### What does this PR do?

It adds the new hook useCurrentUser. It pairs with the PR https://github.com/bigbluebutton/bigbluebutton/pull/18799 from the core BBB

### Motivation

The current presentation when fetched by a common user (not presenter), ends up with some crashes in the console (because it hasn't permission to fetch presentation data). So to avoid this situation, the developer can check if the current user has presenter, to proceed with visualizing the content of current presentation.