### PR TITLE
feat(html5) - New Hook useUsersOverview

### DIFF
--- a/samples/sample-actions-bar-plugin/src/sample-actions-bar-plugin/component.tsx
+++ b/samples/sample-actions-bar-plugin/src/sample-actions-bar-plugin/component.tsx
@@ -30,6 +30,11 @@ function SampleActionsBarPlugin({
     pluginApi.setActionsBarItems([dropdownToUserListItem, buttonToUserListItem]);
   }, []);
 
+  const users: BbbPluginSdk.UserOverview[] = BbbPluginSdk.useUsersOverview();
+
+  useEffect(() => {
+    console.log("Users Overview: ", users);
+  }, [users])
   return null;
 }
 

--- a/src/data-consumption/hooks/index.ts
+++ b/src/data-consumption/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from './presentation';
 export * from './user';
+export * from './useUsersOverview';

--- a/src/data-consumption/hooks/useUsersOverview/index.ts
+++ b/src/data-consumption/hooks/useUsersOverview/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './useUsersOverview';

--- a/src/data-consumption/hooks/useUsersOverview/types.ts
+++ b/src/data-consumption/hooks/useUsersOverview/types.ts
@@ -1,0 +1,5 @@
+export interface UserOverview {
+  userId: string;
+  name: string;
+  role: string;
+}

--- a/src/data-consumption/hooks/useUsersOverview/useUsersOverview.ts
+++ b/src/data-consumption/hooks/useUsersOverview/useUsersOverview.ts
@@ -1,0 +1,31 @@
+import { useState, useEffect } from 'react';
+import { Internal } from '../../../index';
+import { UserOverview } from './types';
+import { CustomEventHookWrapper } from '../../../types/common';
+
+export const useUsersOverview: () => UserOverview[] | undefined = () => {
+  const [userInfo, setUserInfo] = useState<UserOverview[] | undefined>();
+  const handleGetUsersUpdateEvent: EventListener = (
+    (event: CustomEventHookWrapper<UserOverview[]>) => {
+      if (event.detail.hook === Internal.BbbHooks.UseUsersOverview) {
+        setUserInfo(event.detail.data);
+      }
+    }) as EventListener;
+  useEffect(() => {
+    window.addEventListener(Internal.BbbHookEvents.Update, handleGetUsersUpdateEvent);
+    window.dispatchEvent(new CustomEvent(Internal.BbbHookEvents.Subscribe, {
+      detail: { hook: Internal.BbbHooks.UseUsersOverview },
+    }));
+    return () => {
+      window.dispatchEvent(new CustomEvent(Internal.BbbHookEvents.Unsubscribe, {
+        detail: { hook: Internal.BbbHooks.UseUsersOverview },
+      }));
+      window.removeEventListener(
+        Internal.BbbHookEvents.Update,
+        handleGetUsersUpdateEvent,
+      );
+    };
+  }, []);
+
+  return userInfo;
+};

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -7,7 +7,8 @@ enum BbbHookEvents {
 enum BbbHooks {
   UseCurrentPresentation = 'BbbHooks::UseCurrentPresentation',
   UseLoadedUserList = 'BbbHooks::UseLoadedUserList',
-  UseCurrentUser = 'BbbHooks::UseCurrentUser'
+  UseCurrentUser = 'BbbHooks::UseCurrentUser',
+  UseUsersOverview = 'BbbHooks::UseUsersOverview'
 }
 
 enum BbbDataChannel {


### PR DESCRIPTION
### What does this PR do?

It adds support for the new hook `useUsersOverview`, though it doesn't include a new plugin sample specially made for it. The sample it is included is the `SampleActionsBarPlugin`, which just logs a message in the console with all the users in it.

### More

Closely related to https://github.com/bigbluebutton/bigbluebutton/pull/19028

