### PR TITLE
fix: change return type of useDataChannel

### DIFF
--- a/samples/sample-data-channel-plugin/src/sample-data-channel-plugin-item/component.tsx
+++ b/samples/sample-data-channel-plugin/src/sample-data-channel-plugin-item/component.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useEffect } from 'react';
 
-import { BbbPluginSdk, PluginApi, Role, ToRole, ToUserId } from 'bigbluebutton-html-plugin-sdk';
+import { BbbPluginSdk, PluginApi, DataChannelDispatcherUserRole, ToRole, ToUserId } from 'bigbluebutton-html-plugin-sdk';
 import { SampleDataChannelPluginProps } from './types';
 
 interface DataExampleType {
@@ -27,7 +27,7 @@ function SampleDataChannelPlugin(
       second_example_field: 'string as an example',
     } as DataExampleType, [
       {
-        role: Role.MODERATOR
+        role: DataChannelDispatcherUserRole.MODERATOR
       } as ToRole,
       {
         userId: 'userId-123'

--- a/src/data-channel/hooks.ts
+++ b/src/data-channel/hooks.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import {
+  DataChannelMessagesWrapper,
   DispatcherFunction,
   UseDataChannelStaticFunction,
 } from './types';
@@ -19,15 +20,19 @@ export const createChannelIdentifier = (channelName: string, pluginName: string)
 export const useDataChannel = (<T>(channelName: string,
   pluginName: string, pluginApi: PluginApi,
   ) => {
-  const [data, setData] = useState<GraphqlResponseWrapper<T>>({ loading: true });
+  const [data, setData] = useState<GraphqlResponseWrapper<DataChannelMessagesWrapper<T>>>(
+    { loading: true },
+  );
   const [dispatcherFunction, setDispatcherFunction] = useState<DispatcherFunction>();
 
   const channelIdentifier = createChannelIdentifier(channelName, pluginName);
 
   const handleDataChange: EventListener = ((
-    customEvent: HookEventWrapper<GraphqlResponseWrapper<T>>,
+    customEvent: HookEventWrapper<GraphqlResponseWrapper<DataChannelMessagesWrapper<T>>>,
   ) => {
-    const eventDetail = customEvent.detail as UpdatedEventDetails<GraphqlResponseWrapper<T>>;
+    const eventDetail = customEvent.detail as UpdatedEventDetails<
+      GraphqlResponseWrapper<DataChannelMessagesWrapper<T>>
+    >;
     setData(eventDetail.data);
   }) as EventListener;
 

--- a/src/data-channel/types.ts
+++ b/src/data-channel/types.ts
@@ -28,11 +28,25 @@ export interface MapOfDispatchers {
   [key: string]: DispatcherFunction
 }
 
+export interface DataChannelMessageResponseType<T> {
+  createdAt: string;
+  dataChannel: string;
+  fromUserId: string;
+  messageId: string;
+  payloadJson: T;
+  pluginName: string;
+  toRoles: string[];
+}
+
+export interface DataChannelMessagesWrapper<T> {
+  pluginDataChannelMessage: DataChannelMessageResponseType<T>[];
+}
+
 export type UseDataChannelFunctionFromPluginApi = <T>(
   channelName: string,
-) => [GraphqlResponseWrapper<T>, DispatcherFunction];
+) => [GraphqlResponseWrapper<DataChannelMessagesWrapper<T>>, DispatcherFunction];
 
 export type UseDataChannelStaticFunction = <T>(
   channelName: string, pluginName: string,
   pluginApi: PluginApi,
-) => [GraphqlResponseWrapper<T>, DispatcherFunction?];
+) => [GraphqlResponseWrapper<DataChannelMessagesWrapper<T>>, DispatcherFunction?];


### PR DESCRIPTION
### What this PR do?

It basically changes the return type of the hook `useDataChannel` to make it simpler for the plugin developer to fetch data from this hook.

### Closes

Closes #56