### PR TITLE
feat(html5): create useTalkingIndicator and set for external video volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ SDK for developing BigBlueButton plugins, examples of implementations can be fou
 
 - `usePluginSettings` hook: it provides all the specific settings regarding the current plugin it's been loaded from.
 
+- `useTalkingIndicator` hook: it gives you invormation on the user-voice data, that is, who is talking or muted.
+
 ### Real time data exchange
 - `useDataChannel` hook: this will allow you to exchange information (Send and receive) amongst different users through the same plugin;
 
@@ -60,6 +62,9 @@ SDK for developing BigBlueButton plugins, examples of implementations can be fou
     - form: 
       - open: this function will open the sidebar chat panel automatically;
       - fill: this function will fill the form input field of the chat passed in the argument as {text: string}
+  - external-video:
+    - volume:
+      - set: this function will set the external video volume to a certain number between 0 and 1 (that is 0% and);
 
 ### Dom Element Manipulation
 - `useChatMessageDomElements` hook: This hook will return the dom element of a chat message reactively, so one can modify whatever is inside, such as text, css, js, etc.;

--- a/src/core/api/BbbPluginSdk.ts
+++ b/src/core/api/BbbPluginSdk.ts
@@ -36,6 +36,8 @@ import { useUiEvent } from '../../ui-events/hooks';
 import { UseLoadedChatMessagesFunction } from '../../data-consumption/domain/chat/loaded-chat-messages/types';
 import { useLoadedChatMessages } from '../../data-consumption/domain/chat/loaded-chat-messages/hooks';
 import { useChatMessageDomElements } from '../../dom-element-manipulation/chat/message/hooks';
+import { UseTalkingIndicatorFunction } from '../../data-consumption/domain/user-voice/talking-indicator/types';
+import { useTalkingIndicator } from '../../data-consumption/domain/user-voice/talking-indicator/hooks';
 
 declare const window: PluginBrowserWindow;
 
@@ -69,6 +71,7 @@ export abstract class BbbPluginSdk {
     pluginApi.useLoadedUserList = (() => useLoadedUserList()) as UseLoadedUserListFunction;
     pluginApi.useCurrentUser = (() => useCurrentUser()) as UseCurrentUserFunction;
     pluginApi.useUsersBasicInfo = (() => useUsersBasicInfo()) as UseUsersBasicInfoFunction;
+    pluginApi.useTalkingIndicator = (() => useTalkingIndicator()) as UseTalkingIndicatorFunction;
     pluginApi.useLoadedChatMessages = (
       () => useLoadedChatMessages()) as UseLoadedChatMessagesFunction;
     pluginApi.useUiEvent = (<

--- a/src/core/api/types.ts
+++ b/src/core/api/types.ts
@@ -23,6 +23,7 @@ import { GetJoinUrlFunction } from '../auxiliary/join-url/types';
 import { UsePluginSettingsFunction } from '../../data-consumption/domain/settings/plugin-settings/types';
 import { UseUiEventFunction } from '../../ui-events/types';
 import { UseLoadedChatMessagesFunction } from '../../data-consumption/domain/chat/loaded-chat-messages/types';
+import { UseTalkingIndicatorFunction } from '../../data-consumption/domain/user-voice/talking-indicator/types';
 
 // Setter Functions for the API
 export type SetPresentationToolbarItems = (presentationToolbarItem:
@@ -134,6 +135,14 @@ export interface PluginApi {
    *
    */
   usePluginSettings?: UsePluginSettingsFunction;
+    /**
+   * Returns an object containing a list user-voice with the main properties of that object,
+   * that being talking (boolean), startTime (number), muted (boolean) and userId (string).
+   *
+   * @returns `GraphqlResponseWrapper` with the list of user-voice.
+   *
+   */
+  useTalkingIndicator?: UseTalkingIndicatorFunction;
   /**
    * Returns an object containing the data on the current presentation being displayed
    * in the presentation area, and its current page.

--- a/src/data-consumption/domain/user-voice/index.ts
+++ b/src/data-consumption/domain/user-voice/index.ts
@@ -1,0 +1,1 @@
+export { UserVoice } from './talking-indicator/types';

--- a/src/data-consumption/domain/user-voice/talking-indicator/hooks.ts
+++ b/src/data-consumption/domain/user-voice/talking-indicator/hooks.ts
@@ -1,0 +1,9 @@
+import { DataConsumptionHooks } from '../../../../data-consumption/enums';
+import { createDataConsumptionHook } from '../../../factory/hookCreator';
+import { UserVoice } from './types';
+
+export const useTalkingIndicator = () => createDataConsumptionHook<
+  UserVoice[]
+>(
+  DataConsumptionHooks.TALKING_INDICATOR,
+);

--- a/src/data-consumption/domain/user-voice/talking-indicator/types.ts
+++ b/src/data-consumption/domain/user-voice/talking-indicator/types.ts
@@ -1,0 +1,10 @@
+import { GraphqlResponseWrapper } from '../../../../core';
+
+export interface UserVoice {
+  talking: boolean;
+  startTime: number;
+  muted: boolean;
+  userId: string;
+}
+
+export type UseTalkingIndicatorFunction = () => GraphqlResponseWrapper<UserVoice[]>;

--- a/src/data-consumption/enums.ts
+++ b/src/data-consumption/enums.ts
@@ -3,5 +3,6 @@ export enum DataConsumptionHooks {
   LOADED_USER_LIST = 'Hooks::UseLoadedUserList',
   CURRENT_USER = 'Hooks::UseCurrentUser',
   LOADED_CHAT_MESSAGES = 'Hooks::UseLoadedChatMessages',
+  TALKING_INDICATOR = 'Hooks::UseTalkingIndicator',
   CUSTOM_SUBSCRIPTION = 'Hooks::CustomSubscription',
 }

--- a/src/data-consumption/index.ts
+++ b/src/data-consumption/index.ts
@@ -1,4 +1,5 @@
 export * from './domain/presentations';
 export * from './domain/chat';
 export * from './domain/users';
+export * from './domain/user-voice';
 export * from './domain/shared';

--- a/src/ui-commands/commands.ts
+++ b/src/ui-commands/commands.ts
@@ -1,5 +1,7 @@
 import { chat } from './chat/commands';
+import { externalVideo } from './external-video/commands';
 
 export const uiCommands = {
   chat,
+  externalVideo
 };

--- a/src/ui-commands/external-video/commands.ts
+++ b/src/ui-commands/external-video/commands.ts
@@ -1,0 +1,5 @@
+import { volume } from './volume/commands';
+
+export const externalVideo = {
+    volume,
+};

--- a/src/ui-commands/external-video/types.ts
+++ b/src/ui-commands/external-video/types.ts
@@ -1,0 +1,5 @@
+import { UiCommandsExternalVideoVolumeObject } from './volume/types';
+
+export interface UiCommandsExternalVideoObject {
+  volume: UiCommandsExternalVideoVolumeObject;
+}

--- a/src/ui-commands/external-video/volume/commands.ts
+++ b/src/ui-commands/external-video/volume/commands.ts
@@ -1,0 +1,26 @@
+import { ExternalVideoVolumeCommandsEnum } from './enums';
+import { SetExternalVideoVolumeCommandArguments } from './types';
+
+export const volume = {
+  /**
+   * Sets the volume of the external video to a certain level. Needs to be a value between 0 and 1.
+   *
+   * @param setExternalVideoVolumeCommandArguments the volume to which the core will set in the external video.
+   * Refer to {@link SetExternalVideoVolumeCommandArguments} to understand the argument structure.
+   */
+  set: (setExternalVideoVolumeCommandArguments: SetExternalVideoVolumeCommandArguments) => {
+    const volumeToBeSet = setExternalVideoVolumeCommandArguments.volume;
+    if (volumeToBeSet <= 1 && volumeToBeSet >= 0) {
+      window.dispatchEvent(
+        new CustomEvent<
+        SetExternalVideoVolumeCommandArguments
+        >(ExternalVideoVolumeCommandsEnum.SET, {
+          detail: setExternalVideoVolumeCommandArguments,
+        }),
+      );
+    } else {
+      console.warn('Not possible to set a volume less than zero or higher than 1.');
+    }
+    
+  },
+};

--- a/src/ui-commands/external-video/volume/enums.ts
+++ b/src/ui-commands/external-video/volume/enums.ts
@@ -1,0 +1,3 @@
+export enum ExternalVideoVolumeCommandsEnum {
+  SET = 'SET_EXTERNAL_VIDEO_VOLUME_COMMAND',
+}

--- a/src/ui-commands/external-video/volume/types.ts
+++ b/src/ui-commands/external-video/volume/types.ts
@@ -1,0 +1,7 @@
+export interface SetExternalVideoVolumeCommandArguments {
+  volume: number;
+}
+
+export interface UiCommandsExternalVideoVolumeObject {
+  set: (SetExternalVideoVolumeCommandArguments: SetExternalVideoVolumeCommandArguments) => void;
+}

--- a/src/ui-commands/types.ts
+++ b/src/ui-commands/types.ts
@@ -1,4 +1,5 @@
 import { UiCommandsChatObject } from './chat/types';
+import { UiCommandsExternalVideoObject } from './external-video/types';
 
 export interface UiCommandsEventWrapper<T> extends Event{
   detail: T;
@@ -6,4 +7,5 @@ export interface UiCommandsEventWrapper<T> extends Event{
 
 export interface UiCommands {
   chat: UiCommandsChatObject;
+  externalVideo: UiCommandsExternalVideoObject;
 }


### PR DESCRIPTION
### What does this PR do?

It creates new hooks for the plugin SDK:

Data Consumption Hook:
  - `useTalkingIndicator`;

Ui Command:
  - `uiCommands.externalVideo.volume.set`

The first one gives you the information of the user-voice, that being sync with the talking indicator on the meeting and the second gives you the ability to set a specific volume between 0 and 1 of the external video;

### Motivation

Soon there will be an official plugin that decrease the external video when a user is talking, so those two new hooks make it possible


### More

No samples for this one.
Closely related to https://github.com/bigbluebutton/bigbluebutton/pull/19447