### PR TITLE
feat(html5): new server-command for typed-captions plugin

### DIFF
--- a/src/core/api/BbbPluginSdk.ts
+++ b/src/core/api/BbbPluginSdk.ts
@@ -42,6 +42,7 @@ import { useTalkingIndicator } from '../../data-consumption/domain/user-voice/ta
 import { useUiData } from '../../ui-data-hooks/hooks';
 import { UseMeetingFunction } from '../../data-consumption/domain/meeting/from-core/types';
 import { useMeeting } from '../../data-consumption/domain/meeting/from-core/hooks';
+import { serverCommands } from '../../server-commands/commands';
 
 declare const window: PluginBrowserWindow;
 
@@ -84,6 +85,7 @@ export abstract class BbbPluginSdk {
       messageIds: string[],
     ) => useChatMessageDomElements(messageIds);
     pluginApi.uiCommands = uiCommands;
+    pluginApi.serverCommands = serverCommands;
     pluginApi.useUiData = useUiData;
     const pluginName = pluginApi?.pluginName;
     if (pluginName) {

--- a/src/core/api/types.ts
+++ b/src/core/api/types.ts
@@ -26,6 +26,7 @@ import { UseTalkingIndicatorFunction } from '../../data-consumption/domain/user-
 import { GenericContentInterface } from '../../extensible-areas/generic-content-item/types';
 import { UseUiDataFunction } from '../../ui-data-hooks/types';
 import { UseMeetingFunction } from '../../data-consumption/domain/meeting/from-core/types';
+import { ServerCommands } from '../../server-commands/types';
 
 // Setter Functions for the API
 export type SetPresentationToolbarItems = (presentationToolbarItem:
@@ -185,6 +186,8 @@ export interface PluginApi {
   mapOfPushEntryFunctions: MapOfPushEntryFunctions;
   // --- Ui-Commands ---
   uiCommands?: UiCommands;
+  // --- Server-Commands ---
+  serverCommands?: ServerCommands
   // --- Ui-Data-Hook ---
   /**
    * Function that returns the ui data the developer wants from.

--- a/src/data-channel/index.ts
+++ b/src/data-channel/index.ts
@@ -4,5 +4,6 @@ export {
   ToRole,
   DeleteEntryFunction,
   PushEntryFunction,
+  DataChannelEntryResponseType,
 } from './types';
 export { RESET_DATA_CHANNEL } from './constants';

--- a/src/extensible-areas/generic-content-item/component.ts
+++ b/src/extensible-areas/generic-content-item/component.ts
@@ -42,6 +42,8 @@ export class GenericContentSidekickArea implements GenericContentInterface {
 
   buttonIcon: string = '';
 
+  open: boolean = false;
+
   contentFunction: (element: HTMLElement) => void;
 
   /**
@@ -56,17 +58,19 @@ export class GenericContentSidekickArea implements GenericContentInterface {
    * @param section - section name under which the associated sidebar navigation button will be
    *  displayed
    * @param buttonIcon - the icon of the associated sidebar navigation button
+   * @param open - boolean value to decide wether to start open
    *
    * @returns Object that will be interpreted by the core of Bigbluebutton (HTML5).
    */
   constructor({
-    contentFunction, name, section, buttonIcon,
+    contentFunction, name, section, buttonIcon, open,
   }: GenericContentSidekickAreaProps) {
     this.contentFunction = contentFunction;
     this.name = name;
     this.section = section;
     this.buttonIcon = buttonIcon;
     this.type = GenericContentType.SIDEKICK_AREA;
+    this.open = open;
   }
 
   setItemId: (id: string) => void = (id: string) => {

--- a/src/extensible-areas/generic-content-item/types.ts
+++ b/src/extensible-areas/generic-content-item/types.ts
@@ -12,4 +12,5 @@ export interface GenericContentSidekickAreaProps {
   name: string;
   section: string;
   buttonIcon: string;
+  open: boolean;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ export * from './data-channel';
 
 export * from './ui-data-hooks';
 
+export * from './server-commands';
+
 export * from './core';
 
 export * from './utils';

--- a/src/server-commands/caption/commands.ts
+++ b/src/server-commands/caption/commands.ts
@@ -1,0 +1,29 @@
+import { CaptionCommandsEnum } from './enum';
+import { CaptionSaveCommandArguments } from './types';
+
+export const caption = {
+  /**
+   * Saves caption texts into the Caption graphql collection.
+   *
+   * @param captionSaveCommandArguments the text with which the method will save the caption.
+   * Refer to {@link CaptionSaveCommandArguments} to understand the argument structure.
+   */
+  save: (captionSaveCommandArguments: CaptionSaveCommandArguments) => {
+    window.dispatchEvent(
+      new CustomEvent<
+        CaptionSaveCommandArguments
+      >(CaptionCommandsEnum.SAVE, {
+        detail: captionSaveCommandArguments,
+      }),
+    );
+  },
+  addLocale: (captionAddLocaleCommandArguments: string) => {
+    window.dispatchEvent(
+      new CustomEvent<
+        string
+      >(CaptionCommandsEnum.ADD_LOCALE, {
+        detail: captionAddLocaleCommandArguments,
+      }),
+    );
+  },
+};

--- a/src/server-commands/caption/enum.ts
+++ b/src/server-commands/caption/enum.ts
@@ -1,0 +1,9 @@
+export enum CaptionCommandsEnum {
+  SAVE = 'CAPTION_SAVE_COMMAND',
+  ADD_LOCALE = 'CAPTION_ADD_LOCALE_COMMAND',
+}
+
+export enum CaptionsTypeEnum {
+  AUDIO_TRANSCRIPTION = 'AUDIO_TRANSCRIPTION',
+  TYPED = 'TYPED',
+}

--- a/src/server-commands/caption/types.ts
+++ b/src/server-commands/caption/types.ts
@@ -1,0 +1,10 @@
+export interface CaptionSaveCommandArguments {
+  text: string;
+  locale: string;
+  captionType: string;
+}
+
+export interface ServerCommandsCaptionObject {
+  save: (captionSaveCommandArguments: CaptionSaveCommandArguments) => void;
+  addLocale: (captionAddLocaleCommandArguments: string) => void;
+}

--- a/src/server-commands/commands.ts
+++ b/src/server-commands/commands.ts
@@ -1,0 +1,5 @@
+import { caption } from './caption/commands';
+
+export const serverCommands = {
+  caption,
+};

--- a/src/server-commands/index.ts
+++ b/src/server-commands/index.ts
@@ -1,0 +1,1 @@
+export { CaptionCommandsEnum, CaptionsTypeEnum } from './caption/enum';

--- a/src/server-commands/types.ts
+++ b/src/server-commands/types.ts
@@ -1,0 +1,5 @@
+import { ServerCommandsCaptionObject } from './caption/types';
+
+export interface ServerCommands {
+  caption: ServerCommandsCaptionObject;
+}


### PR DESCRIPTION
### What does this PR do?

This PR essentially creates new server-command to send caption via user and also add a new captionLocale.

Other than that, there are a few bugs found in the data-channel flow such as the remove entry function not working, those are already fixed by now.

### Motivation

As mentioned in the title of this PR it is made to support the new typed-captions plugin.

### More

Closely related to https://github.com/bigbluebutton/bigbluebutton/pull/20518
