### PR TITLE
fix(html5): fix useUserCameraDomElement behavior and did some refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ That being said, here are the extensible areas we have so far:
 - User list item additional information (item, label)
 - Floating window item (floatingWindow)
 - Generic Content (main, sidekick)
+- User Camera Helper (button)
+- Screenshare Helper (button)
 
 Mind that no plugin will interfere into another's extensible area. So feel free to set whatever you need into a certain plugin with no worries.
 

--- a/samples/sample-user-camera-dropdown-plugin/src/sample-user-camera-dropdown-plugin-item/component.tsx
+++ b/samples/sample-user-camera-dropdown-plugin/src/sample-user-camera-dropdown-plugin-item/component.tsx
@@ -9,6 +9,8 @@ import {
   ScreenshareHelperButton,
   UserCameraDropdownOption,
   UserCameraDropdownSeparator,
+  UserCameraHelperButton,
+  UserCameraHelperItemPosition,
 } from 'bigbluebutton-html-plugin-sdk';
 import { SampleUserCameraDropdownPluginProps, VideoStreamsSubscriptionResultType } from './types';
 import { VIDEO_STREAMS_SUBSCRIPTION } from '../queries';
@@ -107,6 +109,19 @@ React.ReactElement<SampleUserCameraDropdownPluginProps> {
         onClick: ({ userId, streamId, browserClickEvent }) => {
           pluginLogger.info(`Alert sent from plugin, see userId: ${userId}; ${streamId}; ${browserClickEvent.clientX}`);
         },
+      }),
+    ]);
+    pluginApi.setUserCameraHelperItems([
+      new UserCameraHelperButton({
+        icon: 'popout_window',
+        disabled: false,
+        label: 'This will log on the console',
+        tooltip: 'this is a button injected by plugin',
+        position: UserCameraHelperItemPosition.TOP_RIGHT,
+        onClick: () => {
+          pluginLogger.info('Logging from the screenshare extensible area');
+        },
+        displayFunction: ({ userId }) => randomElement?.user.userId === userId,
       }),
     ]);
   }, [videoStreams]);

--- a/samples/sample-user-camera-dropdown-plugin/src/sample-user-camera-dropdown-plugin-item/component.tsx
+++ b/samples/sample-user-camera-dropdown-plugin/src/sample-user-camera-dropdown-plugin-item/component.tsx
@@ -26,7 +26,7 @@ React.ReactElement<SampleUserCameraDropdownPluginProps> {
     videoStreams?.user_camera.map((vs) => vs.streamId),
   );
 
-  pluginLogger.info(`logging the domElements manipulation for userCamera: (${userCamera}) for streams (${videoStreams})`);
+  pluginLogger.info(`logging the domElements manipulation for userCamera: (${userCamera?.length}) for streams (${videoStreams})`);
 
   useEffect(() => {
     const buttonScreenshare1 = new ScreenshareHelperButton({
@@ -47,8 +47,8 @@ React.ReactElement<SampleUserCameraDropdownPluginProps> {
       label: 'This will log on the console',
       tooltip: 'this is a button injected by plugin',
       position: ScreenshareHelperItemPosition.TOP_RIGHT,
-      onClick: () => {
-        pluginLogger.info('Logging from the screenshare extensible area');
+      onClick: (event) => {
+        pluginLogger.info('Logging from the screenshare extensible area, clientX: ', event.browserClickEvent.clientX);
       },
       hasSeparator: true,
     });

--- a/samples/sample-user-camera-dropdown-plugin/src/sample-user-camera-dropdown-plugin-item/component.tsx
+++ b/samples/sample-user-camera-dropdown-plugin/src/sample-user-camera-dropdown-plugin-item/component.tsx
@@ -49,8 +49,8 @@ React.ReactElement<SampleUserCameraDropdownPluginProps> {
       label: 'This will log on the console',
       tooltip: 'this is a button injected by plugin',
       position: ScreenshareHelperItemPosition.TOP_RIGHT,
-      onClick: (event) => {
-        pluginLogger.info('Logging from the screenshare extensible area, clientX: ', event.browserClickEvent.clientX);
+      onClick: ({ browserClickEvent }) => {
+        pluginLogger.info('Logging from the screenshare extensible area, clientX: ', browserClickEvent.clientX);
       },
       hasSeparator: true,
     });

--- a/samples/sample-user-camera-dropdown-plugin/src/sample-user-camera-dropdown-plugin-item/component.tsx
+++ b/samples/sample-user-camera-dropdown-plugin/src/sample-user-camera-dropdown-plugin-item/component.tsx
@@ -118,8 +118,8 @@ React.ReactElement<SampleUserCameraDropdownPluginProps> {
         label: 'This will log on the console',
         tooltip: 'this is a button injected by plugin',
         position: UserCameraHelperItemPosition.TOP_RIGHT,
-        onClick: () => {
-          pluginLogger.info('Logging from the screenshare extensible area');
+        onClick: ({ browserClickEvent }) => {
+          pluginLogger.info('Logging from the user camera extensible area', browserClickEvent.clientX);
         },
         displayFunction: ({ userId }) => randomElement?.user.userId === userId,
       }),

--- a/src/core/api/BbbPluginSdk.ts
+++ b/src/core/api/BbbPluginSdk.ts
@@ -86,10 +86,10 @@ export abstract class BbbPluginSdk {
       () => useLoadedChatMessages()) as UseLoadedChatMessagesFunction;
     pluginApi.useChatMessageDomElements = (
       messageIds: string[],
-    ) => useChatMessageDomElements(messageIds);
+    ) => useChatMessageDomElements(messageIds, uuid);
     pluginApi.useUserCameraDomElements = (
       streamIds: string[],
-    ) => useUserCameraDomElements(streamIds);
+    ) => useUserCameraDomElements(streamIds, uuid);
     pluginApi.uiCommands = uiCommands;
     pluginApi.useUiData = useUiData;
     const pluginName = pluginApi?.pluginName;

--- a/src/core/api/BbbPluginSdk.ts
+++ b/src/core/api/BbbPluginSdk.ts
@@ -154,6 +154,7 @@ export abstract class BbbPluginSdk {
         setPresentationDropdownItems: () => [],
         setNavBarItems: () => [],
         setScreenshareHelperItems: () => [],
+        setUserCameraHelperItems: () => [],
         setOptionsDropdownItems: () => [],
         setCameraSettingsDropdownItems: () => [],
         setUserCameraDropdownItems: () => [],

--- a/src/core/api/types.ts
+++ b/src/core/api/types.ts
@@ -29,7 +29,7 @@ import { UseMeetingFunction } from '../../data-consumption/domain/meeting/from-c
 import { ServerCommands } from '../../server-commands/types';
 import { SendGenericDataForLearningAnalyticsDashboard } from '../../learning-analytics-dashboard/types';
 import { UseUserCameraDomElementsFunction } from '../../dom-element-manipulation/user-camera/types';
-import { ScreenshareHelperInterface } from '../../extensible-areas';
+import { ScreenshareHelperInterface, UserCameraHelperInterface } from '../../extensible-areas';
 
 // Setter Functions for the API
 export type SetPresentationToolbarItems = (presentationToolbarItem:
@@ -61,6 +61,10 @@ export type SetNavBarItems = (
 
 export type SetScreenshareHelperItems = (
   screenshareHelperItem: ScreenshareHelperInterface[]
+) => string[];
+
+export type SetUserCameraHelperItems = (
+  userCameraHelperItem: UserCameraHelperInterface[]
 ) => string[];
 
 export type SetOptionsDropdownItems = (
@@ -97,6 +101,7 @@ export interface PluginApi {
   setPresentationDropdownItems: SetPresentationDropdownItems;
   setNavBarItems: SetNavBarItems;
   setScreenshareHelperItems: SetScreenshareHelperItems;
+  setUserCameraHelperItems: SetUserCameraHelperItems;
   setOptionsDropdownItems: SetOptionsDropdownItems;
   setCameraSettingsDropdownItems: SetCameraSettingsDropdownItems;
   setUserCameraDropdownItems: SetUserCameraDropdownItems;

--- a/src/core/enum.ts
+++ b/src/core/enum.ts
@@ -3,9 +3,10 @@ import { DomElementManipulationHooks } from '../dom-element-manipulation/enums';
 import { DataConsumptionHooks } from '../data-consumption/enums';
 
 export enum HookEvents {
-  UPDATED = 'HOOK_DATA_UPDATED',
-  SUBSCRIBED = 'PLUGIN_SUBSCRIBED_TO_HOOK',
-  UNSUBSCRIBED = 'PLUGIN_UNSUBSCRIBED_FROM_HOOK'
+  BBB_CORE_SENT_NEW_DATA = 'BBB_CORE_SENT_NEW_DATA',
+  PLUGIN_MODIFIED_SUBSCRIPTION_TO_BBB_CORE = 'PLUGIN_MODIFIED_SUBSCRIPTION_TO_BBB_CORE',
+  PLUGIN_SUBSCRIBED_TO_BBB_CORE = 'PLUGIN_SUBSCRIBED_TO_BBB_CORE',
+  PLUGIN_UNSUBSCRIBED_FROM_BBB_CORE = 'PLUGIN_UNSUBSCRIBED_FROM_BBB_CORE',
 }
 
 export type Hooks = DataConsumptionHooks | DataChannelHooks | DomElementManipulationHooks;

--- a/src/core/enum.ts
+++ b/src/core/enum.ts
@@ -4,7 +4,12 @@ import { DataConsumptionHooks } from '../data-consumption/enums';
 
 export enum HookEvents {
   BBB_CORE_SENT_NEW_DATA = 'BBB_CORE_SENT_NEW_DATA',
-  PLUGIN_MODIFIED_SUBSCRIPTION_TO_BBB_CORE = 'PLUGIN_MODIFIED_SUBSCRIPTION_TO_BBB_CORE',
+  /**
+   * PLUGIN_SENT_CHANGES_TO_BBB_CORE is used to:
+   *  - Comunicate that the subscription has changed for the dom-element-manipulation hook;
+   *  - Send replace/delete event for useDataChannel;
+   */
+  PLUGIN_SENT_CHANGES_TO_BBB_CORE = 'PLUGIN_SENT_CHANGES_TO_BBB_CORE',
   PLUGIN_SUBSCRIBED_TO_BBB_CORE = 'PLUGIN_SUBSCRIBED_TO_BBB_CORE',
   PLUGIN_UNSUBSCRIBED_FROM_BBB_CORE = 'PLUGIN_UNSUBSCRIBED_FROM_BBB_CORE',
 }

--- a/src/data-channel/hooks.ts
+++ b/src/data-channel/hooks.ts
@@ -69,23 +69,27 @@ export const useDataChannelGeneral = (<T>(
       handleListenToChangePushEntryFunction,
     );
 
-    window.dispatchEvent(new CustomEvent<SubscribedEventDetails>(HookEvents.PLUGIN_SUBSCRIBED_TO_BBB_CORE, {
-      detail: {
-        hook: DataChannelHooks.DATA_CHANNEL_BUILDER,
-        hookArguments: {
-          channelName, pluginName, dataChannelType, subChannelName,
-        },
-      },
-    }));
-    return () => {
-      window.dispatchEvent(new CustomEvent<UnsubscribedEventDetails>(HookEvents.PLUGIN_UNSUBSCRIBED_FROM_BBB_CORE, {
+    window.dispatchEvent(
+      new CustomEvent<SubscribedEventDetails>(HookEvents.PLUGIN_SUBSCRIBED_TO_BBB_CORE, {
         detail: {
           hook: DataChannelHooks.DATA_CHANNEL_BUILDER,
           hookArguments: {
             channelName, pluginName, dataChannelType, subChannelName,
           },
         },
-      }));
+      }),
+    );
+    return () => {
+      window.dispatchEvent(
+        new CustomEvent<UnsubscribedEventDetails>(HookEvents.PLUGIN_UNSUBSCRIBED_FROM_BBB_CORE, {
+          detail: {
+            hook: DataChannelHooks.DATA_CHANNEL_BUILDER,
+            hookArguments: {
+              channelName, pluginName, dataChannelType, subChannelName,
+            },
+          },
+        }),
+      );
       window.removeEventListener(channelIdentifier, handleDataChange);
     };
   }, []);

--- a/src/data-channel/hooks.ts
+++ b/src/data-channel/hooks.ts
@@ -69,7 +69,7 @@ export const useDataChannelGeneral = (<T>(
       handleListenToChangePushEntryFunction,
     );
 
-    window.dispatchEvent(new CustomEvent<SubscribedEventDetails>(HookEvents.SUBSCRIBED, {
+    window.dispatchEvent(new CustomEvent<SubscribedEventDetails>(HookEvents.PLUGIN_SUBSCRIBED_TO_BBB_CORE, {
       detail: {
         hook: DataChannelHooks.DATA_CHANNEL_BUILDER,
         hookArguments: {
@@ -78,7 +78,7 @@ export const useDataChannelGeneral = (<T>(
       },
     }));
     return () => {
-      window.dispatchEvent(new CustomEvent<UnsubscribedEventDetails>(HookEvents.UNSUBSCRIBED, {
+      window.dispatchEvent(new CustomEvent<UnsubscribedEventDetails>(HookEvents.PLUGIN_UNSUBSCRIBED_FROM_BBB_CORE, {
         detail: {
           hook: DataChannelHooks.DATA_CHANNEL_BUILDER,
           hookArguments: {

--- a/src/data-channel/utils.ts
+++ b/src/data-channel/utils.ts
@@ -31,7 +31,7 @@ export const deleteEntryFunctionUtil = (
   objectsToDelete.forEach((objectToDelete) => {
     if (objectToDelete === RESET_DATA_CHANNEL) {
       window.dispatchEvent(
-        new CustomEvent<UpdatedEventDetails<void>>(HookEvents.BBB_CORE_SENT_NEW_DATA, {
+        new CustomEvent<UpdatedEventDetails<void>>(HookEvents.PLUGIN_SENT_CHANGES_TO_BBB_CORE, {
           detail: {
             hook: DataChannelHooks.DATA_CHANNEL_RESET,
             hookArguments: { channelName, pluginName, subChannelName },
@@ -41,7 +41,7 @@ export const deleteEntryFunctionUtil = (
       );
     } else {
       window.dispatchEvent(
-        new CustomEvent<UpdatedEventDetails<string>>(HookEvents.BBB_CORE_SENT_NEW_DATA, {
+        new CustomEvent<UpdatedEventDetails<string>>(HookEvents.PLUGIN_SENT_CHANGES_TO_BBB_CORE, {
           detail: {
             hook: DataChannelHooks.DATA_CHANNEL_DELETE,
             hookArguments: { channelName, pluginName, subChannelName },
@@ -62,15 +62,16 @@ export const replaceEntryFunctionUtil = <T>(
 ) => {
   window.dispatchEvent(
     new CustomEvent<
-      UpdatedEventDetails<ReplaceEntryFunctionArguments<T>>>(HookEvents.BBB_CORE_SENT_NEW_DATA, {
-        detail: {
-          hook: DataChannelHooks.DATA_CHANNEL_REPLACE,
-          hookArguments: { channelName, pluginName, subChannelName },
-          data: {
-            entryId,
-            payloadJson: newPayloadJson,
+      UpdatedEventDetails<
+        ReplaceEntryFunctionArguments<T>>>(HookEvents.PLUGIN_SENT_CHANGES_TO_BBB_CORE, {
+          detail: {
+            hook: DataChannelHooks.DATA_CHANNEL_REPLACE,
+            hookArguments: { channelName, pluginName, subChannelName },
+            data: {
+              entryId,
+              payloadJson: newPayloadJson,
+            },
           },
-        },
-      }),
+        }),
   );
 };

--- a/src/data-channel/utils.ts
+++ b/src/data-channel/utils.ts
@@ -30,21 +30,25 @@ export const deleteEntryFunctionUtil = (
 ) => {
   objectsToDelete.forEach((objectToDelete) => {
     if (objectToDelete === RESET_DATA_CHANNEL) {
-      window.dispatchEvent(new CustomEvent<UpdatedEventDetails<void>>(HookEvents.UPDATED, {
-        detail: {
-          hook: DataChannelHooks.DATA_CHANNEL_RESET,
-          hookArguments: { channelName, pluginName, subChannelName },
-          data: undefined,
-        },
-      }));
+      window.dispatchEvent(
+        new CustomEvent<UpdatedEventDetails<void>>(HookEvents.BBB_CORE_SENT_NEW_DATA, {
+          detail: {
+            hook: DataChannelHooks.DATA_CHANNEL_RESET,
+            hookArguments: { channelName, pluginName, subChannelName },
+            data: undefined,
+          },
+        }),
+      );
     } else {
-      window.dispatchEvent(new CustomEvent<UpdatedEventDetails<string>>(HookEvents.UPDATED, {
-        detail: {
-          hook: DataChannelHooks.DATA_CHANNEL_DELETE,
-          hookArguments: { channelName, pluginName, subChannelName },
-          data: objectToDelete,
-        },
-      }));
+      window.dispatchEvent(
+        new CustomEvent<UpdatedEventDetails<string>>(HookEvents.BBB_CORE_SENT_NEW_DATA, {
+          detail: {
+            hook: DataChannelHooks.DATA_CHANNEL_DELETE,
+            hookArguments: { channelName, pluginName, subChannelName },
+            data: objectToDelete,
+          },
+        }),
+      );
     }
   });
 };
@@ -57,15 +61,16 @@ export const replaceEntryFunctionUtil = <T>(
   newPayloadJson: T,
 ) => {
   window.dispatchEvent(
-    new CustomEvent<UpdatedEventDetails<ReplaceEntryFunctionArguments<T>>>(HookEvents.UPDATED, {
-      detail: {
-        hook: DataChannelHooks.DATA_CHANNEL_REPLACE,
-        hookArguments: { channelName, pluginName, subChannelName },
-        data: {
-          entryId,
-          payloadJson: newPayloadJson,
+    new CustomEvent<
+      UpdatedEventDetails<ReplaceEntryFunctionArguments<T>>>(HookEvents.BBB_CORE_SENT_NEW_DATA, {
+        detail: {
+          hook: DataChannelHooks.DATA_CHANNEL_REPLACE,
+          hookArguments: { channelName, pluginName, subChannelName },
+          data: {
+            entryId,
+            payloadJson: newPayloadJson,
+          },
         },
-      },
-    }),
+      }),
   );
 };

--- a/src/data-consumption/factory/hookCreator.ts
+++ b/src/data-consumption/factory/hookCreator.ts
@@ -25,7 +25,7 @@ const updateCustomHookSubscription = (
   currentVariables?: object,
 ) => {
   window.dispatchEvent(
-    new CustomEvent<UnsubscribedEventDetails>(HookEvents.UNSUBSCRIBED, {
+    new CustomEvent<UnsubscribedEventDetails>(HookEvents.PLUGIN_UNSUBSCRIBED_FROM_BBB_CORE, {
       detail: {
         hook: hookName,
         hookArguments: {
@@ -36,7 +36,7 @@ const updateCustomHookSubscription = (
     }),
   );
   window.dispatchEvent(
-    new CustomEvent<SubscribedEventDetails>(HookEvents.SUBSCRIBED, {
+    new CustomEvent<SubscribedEventDetails>(HookEvents.PLUGIN_SUBSCRIBED_TO_BBB_CORE, {
       detail: {
         hook: hookName,
         hookArguments: {
@@ -47,7 +47,7 @@ const updateCustomHookSubscription = (
     }),
   );
   window.addEventListener(
-    HookEvents.UPDATED,
+    HookEvents.BBB_CORE_SENT_NEW_DATA,
     handleCustomSubscriptionUpdateEvent,
   );
 };
@@ -90,9 +90,9 @@ export const createDataConsumptionHook = <T>(
     setVariablesState(() => JSON.parse(sortedStringify(hookArguments?.variables)));
   }
   useEffect(() => {
-    window.addEventListener(HookEvents.UPDATED, handleCustomSubscriptionUpdateEvent);
+    window.addEventListener(HookEvents.BBB_CORE_SENT_NEW_DATA, handleCustomSubscriptionUpdateEvent);
     window.dispatchEvent(
-      new CustomEvent<SubscribedEventDetails>(HookEvents.SUBSCRIBED, {
+      new CustomEvent<SubscribedEventDetails>(HookEvents.PLUGIN_SUBSCRIBED_TO_BBB_CORE, {
         detail: {
           hook: hookName,
           hookArguments,
@@ -101,7 +101,7 @@ export const createDataConsumptionHook = <T>(
     );
     return () => {
       window.dispatchEvent(
-        new CustomEvent<UnsubscribedEventDetails>(HookEvents.UNSUBSCRIBED, {
+        new CustomEvent<UnsubscribedEventDetails>(HookEvents.PLUGIN_UNSUBSCRIBED_FROM_BBB_CORE, {
           detail: {
             hook: hookName,
             hookArguments: {
@@ -112,7 +112,7 @@ export const createDataConsumptionHook = <T>(
         }),
       );
       window.removeEventListener(
-        HookEvents.UPDATED,
+        HookEvents.BBB_CORE_SENT_NEW_DATA,
         handleCustomSubscriptionUpdateEvent,
       );
     };

--- a/src/dom-element-manipulation/chat/message/hooks.ts
+++ b/src/dom-element-manipulation/chat/message/hooks.ts
@@ -65,7 +65,7 @@ export const useChatMessageDomElements = (messageIds: string[], pluginUuid: stri
     window.addEventListener(HookEvents.BBB_CORE_SENT_NEW_DATA, handleDomElementUpdateEvent);
     window.dispatchEvent(
       new CustomEvent<
-        UpdatedEventDetails<void>>(HookEvents.PLUGIN_MODIFIED_SUBSCRIPTION_TO_BBB_CORE, {
+        UpdatedEventDetails<void>>(HookEvents.PLUGIN_SENT_CHANGES_TO_BBB_CORE, {
           detail: {
             hook: DomElementManipulationHooks.CHAT_MESSAGE,
             hookArguments: {

--- a/src/dom-element-manipulation/chat/message/hooks.ts
+++ b/src/dom-element-manipulation/chat/message/hooks.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { DomElementManipulationHooks } from '../../enums';
 import { HookEvents } from '../../../core/enum';
 import {
@@ -7,56 +7,83 @@ import {
 import { ChatMessageDomElementsArguments, UpdatedEventDetailsForChatMessageDomElements } from './types';
 import { sortedStringify } from '../../../data-consumption/utils';
 
-export const useChatMessageDomElements = (messageIds: string[]) => {
+export const useChatMessageDomElements = (messageIds: string[], pluginUuid: string) => {
   const [domElement, setDomElement] = useState<HTMLDivElement[]>();
-  const [messageIdsState, setMessageIdsState] = useState<string[]>(messageIds);
+  const [messageIdsState, setMessageIdsState] = useState<string[]>((messageIds) || []);
 
-  const handleCustomSubscriptionUpdateEvent: EventListener = (
-    (event: HookEventWrapper<
-      UpdatedEventDetails<UpdatedEventDetailsForChatMessageDomElements[]>>) => {
-      const detail = event.detail as UpdatedEventDetails<
+  const previousNeededIds = useRef<string[]>();
+
+  const handleDomElementUpdateEvent: EventListener = (
+      (event: HookEventWrapper<
+        UpdatedEventDetails<UpdatedEventDetailsForChatMessageDomElements[]>>) => {
+        const detail = event.detail as UpdatedEventDetails<
         UpdatedEventDetailsForChatMessageDomElements[]>;
-      if (detail.hook === DomElementManipulationHooks.CHAT_MESSAGE
-        && sortedStringify(
-          detail.data.map((message) => message.messageId),
-        ) === sortedStringify(messageIdsState)) {
-        setDomElement(detail.data.map((message) => message.message));
-      }
-    }) as EventListener;
-
+        if (detail.hook === DomElementManipulationHooks.CHAT_MESSAGE) {
+          const filteredDataFromBbbCore = detail.data?.filter(
+            (item) => messageIdsState.includes(item.messageId),
+          ) || [];
+          const filteredStreamIdsFromBbbCore = filteredDataFromBbbCore.map(
+            (item) => item.messageId,
+          );
+          if (sortedStringify(filteredStreamIdsFromBbbCore)
+            !== sortedStringify(previousNeededIds.current)) {
+            previousNeededIds.current = [...filteredStreamIdsFromBbbCore];
+            setDomElement(
+              filteredDataFromBbbCore.map((messageItemFromCore) => messageItemFromCore.message),
+            );
+          }
+        }
+      }) as EventListener;
   useEffect(() => {
-    if (messageIdsState) {
-      window.addEventListener(HookEvents.UPDATED, handleCustomSubscriptionUpdateEvent);
-      return () => {
-        window.removeEventListener(HookEvents.UPDATED, handleCustomSubscriptionUpdateEvent);
-        window.dispatchEvent(new CustomEvent<UnsubscribedEventDetails>(HookEvents.UNSUBSCRIBED, {
-          detail: {
-            hook: DomElementManipulationHooks.CHAT_MESSAGE,
-            hookArguments: {
-              messageIds,
-            } as ChatMessageDomElementsArguments,
-          },
-        }));
-      };
-    }
-    return () => {};
-  }, []);
-  useEffect(() => {
-    if (messageIdsState) {
-      window.removeEventListener(HookEvents.UPDATED, handleCustomSubscriptionUpdateEvent);
-      window.addEventListener(HookEvents.UPDATED, handleCustomSubscriptionUpdateEvent);
-      window.dispatchEvent(new CustomEvent<SubscribedEventDetails>(HookEvents.SUBSCRIBED, {
+    window.dispatchEvent(
+      new CustomEvent<SubscribedEventDetails>(HookEvents.PLUGIN_SUBSCRIBED_TO_BBB_CORE, {
         detail: {
           hook: DomElementManipulationHooks.CHAT_MESSAGE,
           hookArguments: {
             messageIds,
+            pluginUuid,
           } as ChatMessageDomElementsArguments,
         },
-      }));
-    }
+      }),
+    );
+    window.addEventListener(HookEvents.BBB_CORE_SENT_NEW_DATA, handleDomElementUpdateEvent);
+    return () => {
+      window.dispatchEvent(
+        new CustomEvent<UnsubscribedEventDetails>(HookEvents.PLUGIN_UNSUBSCRIBED_FROM_BBB_CORE, {
+          detail: {
+            hook: DomElementManipulationHooks.CHAT_MESSAGE,
+            hookArguments: {
+              messageIds,
+              pluginUuid,
+            } as ChatMessageDomElementsArguments,
+          },
+        }),
+      );
+    };
+  }, []);
+  useEffect(() => {
+    window.addEventListener(HookEvents.BBB_CORE_SENT_NEW_DATA, handleDomElementUpdateEvent);
+    window.dispatchEvent(
+      new CustomEvent<
+        UpdatedEventDetails<void>>(HookEvents.PLUGIN_MODIFIED_SUBSCRIPTION_TO_BBB_CORE, {
+          detail: {
+            hook: DomElementManipulationHooks.CHAT_MESSAGE,
+            hookArguments: {
+              messageIds,
+              pluginUuid,
+            } as ChatMessageDomElementsArguments,
+            data: undefined,
+          },
+        }),
+    );
+    // Runs on code cleanup
+    return () => {
+      // Everytime the state update, we remove the eventListener and then we re-add it.
+      window.removeEventListener(HookEvents.BBB_CORE_SENT_NEW_DATA, handleDomElementUpdateEvent);
+    };
   }, [messageIdsState]);
-  if (sortedStringify(messageIds) !== sortedStringify(messageIdsState)) {
-    setMessageIdsState(messageIds);
+  if (sortedStringify((messageIds) || []) !== sortedStringify(messageIdsState)) {
+    setMessageIdsState((messageIds) || []);
   }
   return domElement;
 };

--- a/src/dom-element-manipulation/chat/message/types.ts
+++ b/src/dom-element-manipulation/chat/message/types.ts
@@ -4,6 +4,7 @@ export type UseChatMessageDomElementsFunction = (
 
 export interface ChatMessageDomElementsArguments {
   messageIds: string[];
+  pluginUuid: string;
 }
 
 export interface UpdatedEventDetailsForChatMessageDomElements {

--- a/src/dom-element-manipulation/user-camera/hooks.ts
+++ b/src/dom-element-manipulation/user-camera/hooks.ts
@@ -1,62 +1,82 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { DomElementManipulationHooks } from '../enums';
 import { HookEvents } from '../../core/enum';
 import {
   HookEventWrapper, SubscribedEventDetails, UnsubscribedEventDetails, UpdatedEventDetails,
 } from '../../core/types';
-import { UserCameraDomElementsArguments, UpdatedEventDetailsForUserCameraDomElement } from './types';
+import { UserCameraDomElementsArguments, UpdatedDataForUserCameraDomElement } from './types';
 import { sortedStringify } from '../../data-consumption/utils';
 
-export const useUserCameraDomElements = (streamIds: string[]) => {
+export const useUserCameraDomElements = (streamIds: string[], pluginUuid: string) => {
   const [domElement, setDomElement] = useState<HTMLDivElement[]>();
-  const [streamIdsState, setStreamIdsState] = useState<string[]>(streamIds);
+  const [streamIdsState, setStreamIdsState] = useState<string[]>((streamIds) || []);
+  const previousNeededIds = useRef<string[]>([]);
 
-  const handleCustomSubscriptionUpdateEvent: EventListener = (
+  const handleDomElementUpdateEvent: EventListener = (
     (event: HookEventWrapper<
-      UpdatedEventDetails<UpdatedEventDetailsForUserCameraDomElement[]>>) => {
+      UpdatedEventDetails<UpdatedDataForUserCameraDomElement[]>>) => {
       const detail = event.detail as UpdatedEventDetails<
-        UpdatedEventDetailsForUserCameraDomElement[]>;
-      if (detail.hook === DomElementManipulationHooks.USER_CAMERA
-        && sortedStringify(
-          detail.data.map((userCamera) => userCamera.streamId),
-        ) === sortedStringify(streamIdsState)) {
-        setDomElement(detail.data.map((userCamera) => userCamera.userCameraDomElement));
+      UpdatedDataForUserCameraDomElement[]>;
+      if (detail.hook === DomElementManipulationHooks.USER_CAMERA) {
+        const filteredDataFromBbbCore = detail.data?.filter(
+          (item) => streamIdsState.includes(item.streamId),
+        ) || [];
+        const filteredStreamIdsFromBbbCore = filteredDataFromBbbCore.map((item) => item.streamId);
+        if (sortedStringify(filteredStreamIdsFromBbbCore)
+          !== sortedStringify(previousNeededIds.current)) {
+          previousNeededIds.current = [...filteredStreamIdsFromBbbCore];
+          setDomElement(
+            filteredDataFromBbbCore.map((userCamera) => userCamera.userCameraDomElement),
+          );
+        }
       }
     }) as EventListener;
 
   useEffect(() => {
-    if (streamIdsState) {
-      window.addEventListener(HookEvents.UPDATED, handleCustomSubscriptionUpdateEvent);
-      return () => {
-        window.removeEventListener(HookEvents.UPDATED, handleCustomSubscriptionUpdateEvent);
-        window.dispatchEvent(new CustomEvent<UnsubscribedEventDetails>(HookEvents.UNSUBSCRIBED, {
-          detail: {
-            hook: DomElementManipulationHooks.USER_CAMERA,
-            hookArguments: {
-              streamIds,
-            } as UserCameraDomElementsArguments,
-          },
-        }));
-      };
-    }
-    return () => {};
-  }, []);
-  useEffect(() => {
-    if (streamIdsState) {
-      window.removeEventListener(HookEvents.UPDATED, handleCustomSubscriptionUpdateEvent);
-      window.addEventListener(HookEvents.UPDATED, handleCustomSubscriptionUpdateEvent);
-      window.dispatchEvent(new CustomEvent<SubscribedEventDetails>(HookEvents.SUBSCRIBED, {
+    window.dispatchEvent(new CustomEvent<SubscribedEventDetails>(HookEvents.PLUGIN_SUBSCRIBED_TO_BBB_CORE, {
+      detail: {
+        hook: DomElementManipulationHooks.USER_CAMERA,
+        hookArguments: {
+          streamIds: streamIdsState,
+          pluginUuid,
+        } as UserCameraDomElementsArguments,
+      },
+    }));
+    return () => {
+      window.dispatchEvent(new CustomEvent<UnsubscribedEventDetails>(HookEvents.PLUGIN_UNSUBSCRIBED_FROM_BBB_CORE, {
         detail: {
           hook: DomElementManipulationHooks.USER_CAMERA,
           hookArguments: {
-            streamIds: streamIdsState,
+            streamIds,
+            pluginUuid,
           } as UserCameraDomElementsArguments,
         },
       }));
-    }
+    };
+  }, []);
+  useEffect(() => {
+    window.addEventListener(HookEvents.BBB_CORE_SENT_NEW_DATA, handleDomElementUpdateEvent);
+    window.dispatchEvent(
+      new CustomEvent<UpdatedEventDetails<void>>(HookEvents.PLUGIN_MODIFIED_SUBSCRIPTION_TO_BBB_CORE, {
+        detail: {
+          hook: DomElementManipulationHooks.USER_CAMERA,
+          hookArguments: {
+            streamIds: (streamIdsState) || [],
+            pluginUuid,
+          } as UserCameraDomElementsArguments,
+          data: undefined,
+        },
+      }),
+    );
+    // Runs on code cleanup
+    return () => {
+      // Everytime the state update, we remove the eventListener and then we re-add it.
+      window.removeEventListener(HookEvents.BBB_CORE_SENT_NEW_DATA, handleDomElementUpdateEvent);
+    };
   }, [streamIdsState]);
-  if (sortedStringify(streamIds) !== sortedStringify(streamIdsState)) {
-    setStreamIdsState(streamIds);
+
+  if (sortedStringify((streamIds) || []) !== sortedStringify(streamIdsState)) {
+    setStreamIdsState((streamIds) || []);
   }
   return domElement;
 };

--- a/src/dom-element-manipulation/user-camera/hooks.ts
+++ b/src/dom-element-manipulation/user-camera/hooks.ts
@@ -33,40 +33,45 @@ export const useUserCameraDomElements = (streamIds: string[], pluginUuid: string
     }) as EventListener;
 
   useEffect(() => {
-    window.dispatchEvent(new CustomEvent<SubscribedEventDetails>(HookEvents.PLUGIN_SUBSCRIBED_TO_BBB_CORE, {
-      detail: {
-        hook: DomElementManipulationHooks.USER_CAMERA,
-        hookArguments: {
-          streamIds: streamIdsState,
-          pluginUuid,
-        } as UserCameraDomElementsArguments,
-      },
-    }));
-    return () => {
-      window.dispatchEvent(new CustomEvent<UnsubscribedEventDetails>(HookEvents.PLUGIN_UNSUBSCRIBED_FROM_BBB_CORE, {
+    window.dispatchEvent(
+      new CustomEvent<SubscribedEventDetails>(HookEvents.PLUGIN_SUBSCRIBED_TO_BBB_CORE, {
         detail: {
           hook: DomElementManipulationHooks.USER_CAMERA,
           hookArguments: {
-            streamIds,
+            streamIds: streamIdsState,
             pluginUuid,
           } as UserCameraDomElementsArguments,
         },
-      }));
+      }),
+    );
+    return () => {
+      window.dispatchEvent(
+        new CustomEvent<UnsubscribedEventDetails>(HookEvents.PLUGIN_UNSUBSCRIBED_FROM_BBB_CORE, {
+          detail: {
+            hook: DomElementManipulationHooks.USER_CAMERA,
+            hookArguments: {
+              streamIds,
+              pluginUuid,
+            } as UserCameraDomElementsArguments,
+          },
+        }),
+      );
     };
   }, []);
   useEffect(() => {
     window.addEventListener(HookEvents.BBB_CORE_SENT_NEW_DATA, handleDomElementUpdateEvent);
     window.dispatchEvent(
-      new CustomEvent<UpdatedEventDetails<void>>(HookEvents.PLUGIN_MODIFIED_SUBSCRIPTION_TO_BBB_CORE, {
-        detail: {
-          hook: DomElementManipulationHooks.USER_CAMERA,
-          hookArguments: {
-            streamIds: (streamIdsState) || [],
-            pluginUuid,
-          } as UserCameraDomElementsArguments,
-          data: undefined,
-        },
-      }),
+      new CustomEvent<
+        UpdatedEventDetails<void>>(HookEvents.PLUGIN_SENT_CHANGES_TO_BBB_CORE, {
+          detail: {
+            hook: DomElementManipulationHooks.USER_CAMERA,
+            hookArguments: {
+              streamIds: (streamIdsState) || [],
+              pluginUuid,
+            } as UserCameraDomElementsArguments,
+            data: undefined,
+          },
+        }),
     );
     // Runs on code cleanup
     return () => {

--- a/src/dom-element-manipulation/user-camera/types.ts
+++ b/src/dom-element-manipulation/user-camera/types.ts
@@ -4,9 +4,10 @@ export type UseUserCameraDomElementsFunction = (
 
 export interface UserCameraDomElementsArguments {
   streamIds: string[];
+  pluginUuid: string;
 }
 
-export interface UpdatedEventDetailsForUserCameraDomElement {
+export interface UpdatedDataForUserCameraDomElement {
   streamId: string;
   userCameraDomElement: HTMLDivElement;
 }

--- a/src/extensible-areas/base.ts
+++ b/src/extensible-areas/base.ts
@@ -9,6 +9,7 @@ import { OptionsDropdownItemType } from './options-dropdown-item/enums';
 import { PresentationDropdownItemType } from './presentation-dropdown-item/enums';
 import { PresentationToolbarItemType } from './presentation-toolbar-item/enums';
 import { ScreenshareHelperItemType } from './screenshare-helper-item/enums';
+import { UserCameraHelperItemType } from './user-camera-helper-item/enums';
 import { UserCameraDropdownItemType } from './user-camera-dropdown-item/enums';
 import { UserListDropdownItemType } from './user-list-dropdown-item/enums';
 import { UserListItemAdditionalInformationType } from './user-list-item-additional-information/enums';
@@ -19,7 +20,7 @@ type PluginProvidedUiItemType = PresentationToolbarItemType |
   PresentationDropdownItemType | NavBarItemType | OptionsDropdownItemType |
   CameraSettingsDropdownItemType | UserCameraDropdownItemType |
   UserListItemAdditionalInformationType | FloatingWindowType | GenericContentType |
-  ScreenshareHelperItemType;
+  ScreenshareHelperItemType | UserCameraHelperItemType;
 
 export interface PluginProvidedUiItemDescriptor {
   /** Defined by BigBlueButton Plugin Engine. */

--- a/src/extensible-areas/index.ts
+++ b/src/extensible-areas/index.ts
@@ -9,6 +9,7 @@ export * from './screenshare-helper-item';
 export * from './options-dropdown-item';
 export * from './camera-settings-dropdown-item';
 export * from './user-camera-dropdown-item';
+export * from './user-camera-helper-item';
 export * from './user-list-item-additional-information';
 export * from './floating-window';
 export * from './generic-content-item';

--- a/src/extensible-areas/screenshare-helper-item/component.ts
+++ b/src/extensible-areas/screenshare-helper-item/component.ts
@@ -2,6 +2,7 @@ import { ScreenshareHelperItemType, ScreenshareHelperItemPosition } from './enum
 import {
   ScreenshareHelperButtonProps,
   ScreenshareHelperButtonInterface,
+  ScreenshareHelperButtonOnclickCallback,
 } from './types';
 
 // ScreenshareHelper Extensible Area
@@ -21,7 +22,7 @@ export class ScreenshareHelperButton implements ScreenshareHelperButtonInterface
 
   position: ScreenshareHelperItemPosition;
 
-  onClick: () => void;
+  onClick: (args: ScreenshareHelperButtonOnclickCallback) => void;
 
   /**
    * Returns object to be used in the setter for the Screenshare Helper. In this case,

--- a/src/extensible-areas/screenshare-helper-item/types.ts
+++ b/src/extensible-areas/screenshare-helper-item/types.ts
@@ -5,6 +5,10 @@ export interface ScreenshareHelperInterface extends PluginProvidedUiItemDescript
   position: ScreenshareHelperItemPosition;
 }
 
+export interface ScreenshareHelperButtonOnclickCallback {
+  browserClickEvent: React.MouseEvent<HTMLElement>;
+}
+
 export interface ScreenshareHelperButtonInterface extends ScreenshareHelperInterface{
   label: string;
 
@@ -16,7 +20,7 @@ export interface ScreenshareHelperButtonInterface extends ScreenshareHelperInter
 
   position: ScreenshareHelperItemPosition;
 
-  onClick: () => void;
+  onClick: (args: ScreenshareHelperButtonOnclickCallback) => void;
 }
 
 export interface ScreenshareHelperButtonProps {
@@ -26,5 +30,5 @@ export interface ScreenshareHelperButtonProps {
   disabled: boolean;
   hasSeparator: boolean;
   position: ScreenshareHelperItemPosition;
-  onClick: () => void;
+  onClick: (args: ScreenshareHelperButtonOnclickCallback) => void;
 }

--- a/src/extensible-areas/user-camera-helper-item/component.ts
+++ b/src/extensible-areas/user-camera-helper-item/component.ts
@@ -1,0 +1,63 @@
+import { UserCameraHelperItemType, UserCameraHelperItemPosition } from './enums';
+import {
+  UserCameraHelperButtonProps,
+  UserCameraHelperButtonInterface,
+  UserCameraHelperButtonOnclickCallback,
+  UserCameraHelperCallbackFunctionArguments,
+} from './types';
+
+// UserCameraHelper Extensible Area
+
+export class UserCameraHelperButton implements UserCameraHelperButtonInterface {
+  id: string = '';
+
+  type: UserCameraHelperItemType;
+
+  label: string;
+
+  displayFunction?: (args: UserCameraHelperCallbackFunctionArguments) => boolean;
+
+  icon: string;
+
+  tooltip: string;
+
+  disabled: boolean;
+
+  position: UserCameraHelperItemPosition;
+
+  onClick: (args: UserCameraHelperButtonOnclickCallback) => void;
+
+  /**
+   * Returns object to be used in the setter for the UserCamera Helper. In this case,
+   * a button.
+   *
+   * @param label - label to be displayed in userCamera helper button (Not mandatory).
+   * @param tooltip - label to be displayed when hovering the userCamera helper button.
+   * @param icon - icon to be used in the userCamera helper button. It goes in the left side of it.
+   * @param onClick - function to be called when clicking the button.
+   * @param displayFunction - function to tell BBB core which cameras will receive this extensible
+   * area.
+   * @param position - position to place the userCamera helper button.
+   * See {@link UserCameraHelperItemPosition}
+   * @param disabled - if true, the userCamera helper button will not be clickable
+   *
+   * @returns Object that will be interpreted by the core of Bigbluebutton (HTML5).
+   */
+  constructor({
+    label = '', icon = '', tooltip = '', disabled = true, onClick = () => {},
+    position = UserCameraHelperItemPosition.TOP_RIGHT, displayFunction,
+  }: UserCameraHelperButtonProps) {
+    this.label = label;
+    this.icon = icon;
+    this.tooltip = tooltip;
+    this.disabled = disabled;
+    this.onClick = onClick;
+    this.displayFunction = displayFunction;
+    this.type = UserCameraHelperItemType.BUTTON;
+    this.position = position;
+  }
+
+  setItemId: (id: string) => void = (id: string) => {
+    this.id = `UserCameraHelperButton_${id}`;
+  };
+}

--- a/src/extensible-areas/user-camera-helper-item/enums.ts
+++ b/src/extensible-areas/user-camera-helper-item/enums.ts
@@ -1,0 +1,14 @@
+// UserCamera Helper items types:
+export enum UserCameraHelperItemType {
+  BUTTON = 'SCREENSHARE_HELPER_BUTTON',
+}
+
+/**
+ * Enum with the position to insert the userCamera helper item (Information or Button)
+ */
+export enum UserCameraHelperItemPosition {
+  TOP_RIGHT = 'TOP_RIGHT',
+  TOP_LEFT = 'TOP_LEFT',
+  BOTTOM_RIGHT = 'BOTTOM_RIGHT',
+  BOTTOM_LEFT = 'BOTTOM_LEFT',
+}

--- a/src/extensible-areas/user-camera-helper-item/index.ts
+++ b/src/extensible-areas/user-camera-helper-item/index.ts
@@ -1,0 +1,9 @@
+export {
+  UserCameraHelperButton,
+} from './component';
+export {
+  UserCameraHelperInterface,
+} from './types';
+export {
+  UserCameraHelperItemPosition,
+} from './enums';

--- a/src/extensible-areas/user-camera-helper-item/types.ts
+++ b/src/extensible-areas/user-camera-helper-item/types.ts
@@ -1,0 +1,41 @@
+import { PluginProvidedUiItemDescriptor } from '../base';
+import { UserCameraHelperItemPosition } from './enums';
+
+export interface UserCameraHelperInterface extends PluginProvidedUiItemDescriptor{
+  position: UserCameraHelperItemPosition;
+}
+
+export interface UserCameraHelperButtonOnclickCallback {
+  browserClickEvent: React.MouseEvent<HTMLElement>;
+}
+
+export interface UserCameraHelperCallbackFunctionArguments {
+  streamId: string;
+  userId: string;
+}
+
+export interface UserCameraHelperButtonInterface extends UserCameraHelperInterface{
+  label: string;
+
+  icon: string;
+
+  tooltip: string;
+
+  disabled: boolean;
+
+  position: UserCameraHelperItemPosition;
+
+  displayFunction?: (args: UserCameraHelperCallbackFunctionArguments) => boolean;
+
+  onClick: (args: UserCameraHelperButtonOnclickCallback) => void;
+}
+
+export interface UserCameraHelperButtonProps {
+  label?: string;
+  icon: string;
+  tooltip: string;
+  disabled: boolean;
+  displayFunction?: (args: UserCameraHelperCallbackFunctionArguments) => boolean;
+  position: UserCameraHelperItemPosition;
+  onClick: (args: UserCameraHelperButtonOnclickCallback) => void;
+}

--- a/src/extensible-areas/user-camera-helper-item/types.ts
+++ b/src/extensible-areas/user-camera-helper-item/types.ts
@@ -6,6 +6,8 @@ export interface UserCameraHelperInterface extends PluginProvidedUiItemDescripto
 }
 
 export interface UserCameraHelperButtonOnclickCallback {
+  userId: string;
+  streamId: string;
   browserClickEvent: React.MouseEvent<HTMLElement>;
 }
 


### PR DESCRIPTION
### What does this PR do?

- Adds new extensible area: userCameraHelper (which is a button added in one of the corners of the user camera);
- Fixes useUserCameraDomElement (the issue was that when a new user enters the room, the dom-element-manipulator hook didn't return the elements);
- Adds a click event to the arguments of the onClick callback function of screenshareHelper;
- Refactors naming of plugin hook events so as to add new event informing bbb-core that the plugin is changing something on its side; 

### More

This PR is closely related to the CORE PR https://github.com/bigbluebutton/bigbluebutton/pull/21004

See a demo of the new userCameraHelper down below:

![image](https://github.com/user-attachments/assets/9e9b0f21-0c69-47ab-8a1f-fc029f9be05b)

