### PR TITLE
!fix: track DOM elements in `useChatMessagesDomElements` with pagination

### DIFF
--- a/src/dom-element-manipulation/chat/message/hooks.ts
+++ b/src/dom-element-manipulation/chat/message/hooks.ts
@@ -8,7 +8,7 @@ import { ChatMessageDomElementsArguments, UpdatedEventDetailsForChatMessageDomEl
 import { sortedStringify } from '../../../data-consumption/utils';
 
 export const useChatMessageDomElements = (messageIds: string[], pluginUuid: string) => {
-  const [domElements, setDomElements] = useState<HTMLDivElement[]>();
+  const [domElements, setDomElements] = useState<HTMLDivElement[]>([]);
   const [messageIdsState, setMessageIdsState] = useState<string[]>((messageIds) || []);
 
   const previousNeededIds = useRef<string[]>();

--- a/src/dom-element-manipulation/chat/message/hooks.ts
+++ b/src/dom-element-manipulation/chat/message/hooks.ts
@@ -8,7 +8,7 @@ import { ChatMessageDomElementsArguments, UpdatedEventDetailsForChatMessageDomEl
 import { sortedStringify } from '../../../data-consumption/utils';
 
 export const useChatMessageDomElements = (messageIds: string[], pluginUuid: string) => {
-  const [domElement, setDomElement] = useState<HTMLDivElement[]>();
+  const [domElements, setDomElements] = useState<HTMLDivElement[]>();
   const [messageIdsState, setMessageIdsState] = useState<string[]>((messageIds) || []);
 
   const previousNeededIds = useRef<string[]>();
@@ -28,7 +28,7 @@ export const useChatMessageDomElements = (messageIds: string[], pluginUuid: stri
           if (sortedStringify(filteredStreamIdsFromBbbCore)
             !== sortedStringify(previousNeededIds.current)) {
             previousNeededIds.current = [...filteredStreamIdsFromBbbCore];
-            setDomElement(
+            setDomElements(
               filteredDataFromBbbCore.map((messageItemFromCore) => messageItemFromCore.message),
             );
           }
@@ -85,5 +85,5 @@ export const useChatMessageDomElements = (messageIds: string[], pluginUuid: stri
   if (sortedStringify((messageIds) || []) !== sortedStringify(messageIdsState)) {
     setMessageIdsState((messageIds) || []);
   }
-  return domElement;
+  return domElements;
 };

--- a/src/dom-element-manipulation/chat/message/hooks.ts
+++ b/src/dom-element-manipulation/chat/message/hooks.ts
@@ -27,12 +27,18 @@ export const useChatMessageDomElements = (messageIds: string[], pluginUuid: stri
         UpdatedEventDetailsForChatMessageDomElements>;
         if (detail.hook === DomElementManipulationHooks.CHAT_MESSAGE) {
           const pageToUpdate = detail.data?.page;
+          if (pageToUpdate === undefined) return;
           if (detail.data?.messages.length === 0) {
             // indicates the page was unmounted in the client
             // so we remove all stored elements for that page,
             // since they might be invalid.
-            delete domElements[pageToUpdate];
-            return;
+            setDomElements((domElementsState) => {
+              const newDomElements = {
+                ...domElementsState,
+              };
+              delete newDomElements[pageToUpdate];
+              return newDomElements;
+            });
           }
 
           const pageDomElementsFromBbbCore = detail.data?.messages.map(

--- a/src/dom-element-manipulation/chat/message/types.ts
+++ b/src/dom-element-manipulation/chat/message/types.ts
@@ -7,7 +7,16 @@ export interface ChatMessageDomElementsArguments {
   pluginUuid: string;
 }
 
-export interface UpdatedEventDetailsForChatMessageDomElements {
+export interface MessageDetails {
   messageId: string;
   message: HTMLDivElement;
+}
+
+export interface UpdatedEventDetailsForChatMessageDomElements {
+  page: number;
+  messages: MessageDetails[];
+}
+
+export interface RenderedChatMessages {
+  [pageNumber: number]: HTMLDivElement[];
 }


### PR DESCRIPTION
### What does this PR do?

The `useChatMessagesDomElements` hook was designed to expect all DOM elements from the rendered chat messages to be sent in a single event. However, due to the pagination mechanism in the bbb-core, only messages from the same page are sent together, which caused DOM elements from the last rendered page to overwrite those from previous pages.

This PR introduces support for pagination when storing DOM elements, ensuring that elements from different pages do not overwrite each other. It also includes a cleanup mechanism to remove stored DOM elements when a page is unmounted (due to pagination rolling or chat toggling). This ensures that only valid elements are stored and prevents the list from growing indefinitely.

Additionally, the hook's internal state management has been updated and the filtering for the requested message IDs has been moved to the render function to ensure that the returned DOM elements are correctly updated when message IDs passed via props change.

**Breaking change**: Modified the structure of data exchanged in window events `UpdatedEventDetailsForChatMessageDomElements`.

### Closes Issue(s)
Closes #111

#### Note for reviewer

- When toggling the chat very frequently, the issue may still occur. Based on my investigation, the problem appears to originate from the `useLoadedChatMessages` hook, which is not returning all loaded message IDs in such cases and should be addressed in a separate issue/PR.
- The recommended way to test this PR is to use a plugin(such as [this sample](https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/tree/main/samples/sample-server-commands-plugin)) that utilizes the message IDs returned from `useLoadedChatMessages`and then requests some of those IDs to `useChatMessagesDomElements`.
- Ensure that `useLoadedChatMessages` is returning all IDs correctly.
### More
Relate bbb core PR: https://github.com/bigbluebutton/bigbluebutton/pull/21176
