### PR TITLE
fix(extensible-areas): change return type of `contentFunction`

### DIFF
--- a/samples/sample-action-button-dropdown-plugin/src/components/sample-action-button-dropdown-plugin-item/component.tsx
+++ b/samples/sample-action-button-dropdown-plugin/src/components/sample-action-button-dropdown-plugin-item/component.tsx
@@ -75,6 +75,7 @@ function SampleActionButtonDropdownPlugin(
                 />
               </React.StrictMode>,
             );
+            return root;
           },
         }),
       ]);

--- a/samples/sample-floating-window-plugin/src/sample-floating-window-plugin-item/component.tsx
+++ b/samples/sample-floating-window-plugin/src/sample-floating-window-plugin-item/component.tsx
@@ -51,6 +51,7 @@ function SampleFloatingWindowPlugin(
               />
             </React.StrictMode>,
           );
+          return root;
         },
       });
       pluginApi.setActionsBarItems([]);

--- a/samples/sample-generic-content-sidekick-plugin/src/components/sample-generic-content-sidekick-plugin-item/component.tsx
+++ b/samples/sample-generic-content-sidekick-plugin/src/components/sample-generic-content-sidekick-plugin-item/component.tsx
@@ -22,6 +22,7 @@ function SampleGenericContentSidekickPlugin(
         name: 'Generic Content 1',
         section: 'Section 1',
         buttonIcon: 'video',
+        open: false,
         contentFunction: (element: HTMLElement) => {
           const root = ReactDOM.createRoot(element);
           root.render(
@@ -31,12 +32,14 @@ function SampleGenericContentSidekickPlugin(
               />
             </React.StrictMode>,
           );
+          return root;
         },
       }),
       new GenericContentSidekickArea({
         name: 'Generic Content 2',
         section: 'Section 2',
         buttonIcon: 'chat',
+        open: false,
         contentFunction: (element: HTMLElement) => {
           const root = ReactDOM.createRoot(element);
           root.render(
@@ -46,6 +49,7 @@ function SampleGenericContentSidekickPlugin(
               <iframe title="wikipedia" width="100%" height="1000px" src="https://en.wikipedia.org/wiki/Main_Page" />
             </React.StrictMode>,
           );
+          return root;
         },
       }),
     ]);

--- a/src/extensible-areas/floating-window/component.ts
+++ b/src/extensible-areas/floating-window/component.ts
@@ -1,3 +1,4 @@
+import * as ReactDOM from 'react-dom/client';
 import { FloatingWindowType } from './enums';
 import { FloatingWindowInterface, FloatingWindowProps } from './types';
 
@@ -18,20 +19,21 @@ export class FloatingWindow implements FloatingWindowInterface {
 
   boxShadow: string;
 
-  contentFunction: (element: HTMLElement) => void;
+  contentFunction: (element: HTMLElement) => ReactDOM.Root;
 
   /**
    * Returns object to be used in the setter for the Floating Window
    *
    * @param top - position in which the the top left corner of the floating window is relative
-   * to the top of the rendered window.
+   * to the top of the rendered window. It must return the root element where the floating window
+   * was rendered.
    * @param left - position in which the the top left corner of the floating window is relative
    * to the left of the rendered window.
    * @param movable - tells whether the floating window is movable or static.
    * @param backgroundColor - background color of the floating window.
    * @param boxShadow - box shadow to apply to the floating window
    * @param contentFunction - function that gives the html element to render the content of
-   * the floating window
+   * the floating window. It must return the root element where the floating window was rendered.
    *
    * @returns Object that will be interpreted by the core of Bigbluebutton (HTML5).
    */

--- a/src/extensible-areas/floating-window/types.ts
+++ b/src/extensible-areas/floating-window/types.ts
@@ -1,3 +1,4 @@
+import * as ReactDOM from 'react-dom/client';
 import { PluginProvidedUiItemDescriptor } from '../base';
 
 export interface FloatingWindowInterface extends PluginProvidedUiItemDescriptor {
@@ -9,7 +10,7 @@ export interface FloatingWindowProps {
   movable: boolean;
   backgroundColor: string;
   boxShadow: string;
-  contentFunction: (element: HTMLElement) => void;
+  contentFunction: (element: HTMLElement) => ReactDOM.Root;
 }
 
 export type SetFloatingWindows = (

--- a/src/extensible-areas/generic-content-item/component.ts
+++ b/src/extensible-areas/generic-content-item/component.ts
@@ -1,3 +1,4 @@
+import * as ReactDOM from 'react-dom/client';
 import { GenericContentType } from './enums';
 import { GenericContentInterface, GenericContentMainAreaProps, GenericContentSidekickAreaProps } from './types';
 
@@ -8,7 +9,7 @@ export class GenericContentMainArea implements GenericContentInterface {
 
   type: GenericContentType;
 
-  contentFunction: (element: HTMLElement) => void;
+  contentFunction: (element: HTMLElement) => ReactDOM.Root;
 
   /**
    * Returns an object that when used in the setter as a generic content will be rendered
@@ -44,7 +45,7 @@ export class GenericContentSidekickArea implements GenericContentInterface {
 
   open: boolean = false;
 
-  contentFunction: (element: HTMLElement) => void;
+  contentFunction: (element: HTMLElement) => ReactDOM.Root;
 
   /**
    * Returns an object that when used in the setter as a generic content will be rendered
@@ -53,7 +54,7 @@ export class GenericContentSidekickArea implements GenericContentInterface {
    * given generic sidekick content.
    *
    * @param contentFunction - function that gives the html element to render the content of
-   * the generic component
+   * the generic content. It must return the root element where the generic content was rendered.
    * @param name - the label of the associated sidebar navigation button
    * @param section - section name under which the associated sidebar navigation button will be
    *  displayed

--- a/src/extensible-areas/generic-content-item/types.ts
+++ b/src/extensible-areas/generic-content-item/types.ts
@@ -1,14 +1,15 @@
+import * as ReactDOM from 'react-dom/client';
 import { PluginProvidedUiItemDescriptor } from '../base';
 
 export interface GenericContentInterface extends PluginProvidedUiItemDescriptor {
 }
 
 export interface GenericContentMainAreaProps {
-  contentFunction: (element: HTMLElement) => void;
+  contentFunction: (element: HTMLElement) => ReactDOM.Root;
 }
 
 export interface GenericContentSidekickAreaProps {
-  contentFunction: (element: HTMLElement) => void;
+  contentFunction: (element: HTMLElement) => ReactDOM.Root;
   name: string;
   section: string;
   buttonIcon: string;


### PR DESCRIPTION
### What does this PR do?

Changes the return type of `contentFunction` in FloatingWindow and GenericContent extensible areas.

This change is necessary because the components provided by plugins, when rendered in the core, were left in the DOM Tree. This occurs because the plugins and the core are two separate ReactJS applications, each using its own ReactDOM instance. The `contentFunction` must now return the root element created by the plugin's ReactDOM instance to allow the core to properly unmount it.

### Closes Issue(s)
Closes #112 

### More
Relate Core's PR: 
- https://github.com/bigbluebutton/bigbluebutton/pull/21211
