### PR TITLE
feat(ui-commands): add user status and conference speaker level

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,10 @@ One other thing is that the type of the return is precisely the same type requir
 - presentation-area:
   - open: this function will open the presentation area content automatically;
   - close: this function will close the presentation area content automatically;
+- conference:
+  - setSpeakerLevel: this function will set the speaker volume level(audio output) of the conference to a certain number between 0 and 1;
+- user-status:
+  - setAwayStatus: this function will set the away status of the user to a certain status;
 
 See usage ahead:
 

--- a/src/ui-commands/commands.ts
+++ b/src/ui-commands/commands.ts
@@ -2,10 +2,14 @@ import { chat } from './chat/commands';
 import { externalVideo } from './external-video/commands';
 import { sidekickOptionsContainer } from './sidekick-options-container/commands';
 import { presentationArea } from './presentation-area/commands';
+import { userStatus } from './user-status/commands';
+import { conference } from './conference/commands';
 
 export const uiCommands = {
   chat,
   externalVideo,
   sidekickOptionsContainer,
   presentationArea,
+  userStatus,
+  conference,
 };

--- a/src/ui-commands/conference/commands.ts
+++ b/src/ui-commands/conference/commands.ts
@@ -1,0 +1,29 @@
+import { ConferenceEnum } from './enums';
+import { SetSpeakerLevelCommandArguments } from './types';
+
+export const conference = {
+  /**
+   * Sets the volume of the speakers in the conference to a certain level.
+   * Needs to be a value between 0 and 1.
+   *
+   * @param setSpeakerLevelCommandArgumentsthe volume to which the core will set the speaker
+   * level.
+   * Refer to {@link SetSpeakerLevelCommandArguments} to understand the argument structure.
+   */
+  setSpeakerLevel: (setSpeakerLevelCommandArguments: SetSpeakerLevelCommandArguments) => {
+    const { level } = setSpeakerLevelCommandArguments;
+    if (level <= 1 && level >= 0) {
+      window.dispatchEvent(
+        new CustomEvent<
+          SetSpeakerLevelCommandArguments
+        >(ConferenceEnum.SET_SPEAKER_LEVEL, {
+          detail: {
+            level,
+          },
+        }),
+      );
+    } else {
+      throw new Error('Not possible to set the speaker volume less than zero or higher than one');
+    }
+  },
+};

--- a/src/ui-commands/conference/enums.ts
+++ b/src/ui-commands/conference/enums.ts
@@ -1,0 +1,3 @@
+export enum ConferenceEnum {
+  SET_SPEAKER_LEVEL = 'SET_SPEAKER_LEVEL_COMMAND',
+}

--- a/src/ui-commands/conference/types.ts
+++ b/src/ui-commands/conference/types.ts
@@ -1,0 +1,7 @@
+export interface SetSpeakerLevelCommandArguments {
+  level: number;
+}
+
+export interface UiCommandsConferenceObject {
+  setSpeakerLevel: (setSpeakerlevelCommandArguments: SetSpeakerLevelCommandArguments) => void;
+}

--- a/src/ui-commands/types.ts
+++ b/src/ui-commands/types.ts
@@ -2,10 +2,14 @@ import { UiCommandsChatObject } from './chat/types';
 import { UiCommandsExternalVideoObject } from './external-video/types';
 import { UiCommandsSidekickOptionsContainerObject } from './sidekick-options-container/types';
 import { UiCommandsPresentationAreaObject } from './presentation-area/types';
+import { UiCommandsUserStatusObject } from './user-status/types';
+import { UiCommandsConferenceObject } from './conference/types';
 
 export interface UiCommands {
   chat: UiCommandsChatObject;
   externalVideo: UiCommandsExternalVideoObject;
   sidekickOptionsContainer: UiCommandsSidekickOptionsContainerObject;
   presentationArea: UiCommandsPresentationAreaObject;
+  userStatus: UiCommandsUserStatusObject;
+  conference: UiCommandsConferenceObject;
 }

--- a/src/ui-commands/user-status/commands.ts
+++ b/src/ui-commands/user-status/commands.ts
@@ -1,0 +1,24 @@
+import { UserStatusEnum } from './enums';
+import { SetAwayStatusCommandArguments } from './types';
+
+export const userStatus = {
+  /**
+   * Sets the away status of the user to a certain status.
+   *
+   * @param setAwayStatusCommandArguments the status to which the core will set the user
+   * status.
+   * Refer to {@link SetAwayStatusCommandArguments} to understand the argument structure.
+   */
+  setAwayStatus: (setAwayStatusCommandArguments: SetAwayStatusCommandArguments) => {
+    const { away } = setAwayStatusCommandArguments;
+    window.dispatchEvent(
+      new CustomEvent<
+        SetAwayStatusCommandArguments
+      >(UserStatusEnum.SET_AWAY_STATUS, {
+        detail: {
+          away,
+        },
+      }),
+    );
+  },
+};

--- a/src/ui-commands/user-status/enums.ts
+++ b/src/ui-commands/user-status/enums.ts
@@ -1,0 +1,3 @@
+export enum UserStatusEnum {
+  SET_AWAY_STATUS = 'SET_AWAY_USER_STATUS_COMMAND',
+}

--- a/src/ui-commands/user-status/types.ts
+++ b/src/ui-commands/user-status/types.ts
@@ -1,0 +1,7 @@
+export interface SetAwayStatusCommandArguments {
+  away: boolean;
+}
+
+export interface UiCommandsUserStatusObject {
+  setAwayStatus: (setAwayStatusCommandArguments: SetAwayStatusCommandArguments) => void;
+}


### PR DESCRIPTION
### What does this PR do?
Adds ui commands to set the user away status and the speaker level(audio output) in the conference.

### Closes Issue(s)
None

### More
Related BBB-core's PR: 
- https://github.com/bigbluebutton/bigbluebutton/pull/21336
