### PR TITLE
feat(plugin-server): Implemented plugin-server integration with SDK.

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,49 @@ So that the data will appear in the following form:
 | user-name |   1   |   `<value>`     |
 
 
+### External data resources
+
+This is the new integration with external servers to fetch data in a secure manner.
+
+This is possible by simply configuring the dataResource name in the manifest and then its endpoint in the URL meta parameter that goes in the create request. The manifest would look like:
+
+```json
+{
+  // ...rest of manifest configuration
+  "remoteDataSources": [
+      {
+          "name": "allUsers",
+          "url": "${meta_pluginSettingsUserInformation}",
+          "fetchMode": "onMeetingCreate",
+          "permissions": ["moderator", "viewer"]
+      }
+  ]
+}
+```
+
+Then when creating the meeting send the following parameters along, adjusting to your needs and resources:
+
+```
+meta_pluginSettingsUserInformation=https://<your-external-source-with-your-authentication>/api/users
+pluginsManifests=[{"url": "http://<domain-of-your-manifest>/your-plugin/manifest.json"}]
+```
+
+In the plugin, just use the function like:
+
+```typescript
+pluginApi.getRemoteData('allUsers').then((response: Response) => {
+  if (response.ok) {
+    response.json().then((r: CourseData) => {
+      // Do something with the jsonified data (if it's a json)
+    }).catch((reason) => {
+      pluginLogger.error('Error while processing the json from success response: ', reason);
+    });
+  }
+}).catch((reason) => {
+  pluginLogger.error('Error while fetching external resource: ', reason);
+});
+```
+
 
 ### Frequently Asked Questions (FAQ)
 

--- a/src/core/api/BbbPluginSdk.ts
+++ b/src/core/api/BbbPluginSdk.ts
@@ -46,6 +46,7 @@ import { useMeeting } from '../../data-consumption/domain/meeting/from-core/hook
 import { serverCommands } from '../../server-commands/commands';
 import { sendGenericDataForLearningAnalyticsDashboard } from '../../learning-analytics-dashboard/hooks';
 import { GenericDataForLearningAnalyticsDashboard } from '../../learning-analytics-dashboard/types';
+import { getRemoteData } from '../../remote-data/utils';
 
 declare const window: PluginBrowserWindow;
 
@@ -110,6 +111,9 @@ export abstract class BbbPluginSdk {
       pluginApi.sendGenericDataForLearningAnalyticsDashboard = (
         data: GenericDataForLearningAnalyticsDashboard,
       ) => sendGenericDataForLearningAnalyticsDashboard(data, pluginName);
+      pluginApi.getRemoteData = (
+        dataSourceName: string,
+      ) => getRemoteData(dataSourceName, pluginName);
     } else {
       throw new Error('Plugin name not set');
     }

--- a/src/core/api/types.ts
+++ b/src/core/api/types.ts
@@ -30,6 +30,7 @@ import { ServerCommands } from '../../server-commands/types';
 import { SendGenericDataForLearningAnalyticsDashboard } from '../../learning-analytics-dashboard/types';
 import { UseUserCameraDomElementsFunction } from '../../dom-element-manipulation/user-camera/types';
 import { ScreenshareHelperInterface, UserCameraHelperInterface } from '../../extensible-areas';
+import { GetDataSource } from '../../remote-data/types';
 
 // Setter Functions for the API
 export type SetPresentationToolbarItems = (presentationToolbarItem:
@@ -242,6 +243,13 @@ export interface PluginApi {
    *
    */
   sendGenericDataForLearningAnalyticsDashboard?: SendGenericDataForLearningAnalyticsDashboard;
+  /**
+   * Fetches external data from pre-defined data-source in manifest.
+   *
+   * @param dataSourceName - name of the data source
+   *
+   */
+  getRemoteData?: GetDataSource;
 }
 
 export interface PluginBrowserWindow extends Window {

--- a/src/remote-data/types.ts
+++ b/src/remote-data/types.ts
@@ -1,0 +1,3 @@
+export type GetDataSource = (
+  dataSourceName: string,
+) => Promise<object>;

--- a/src/remote-data/utils.ts
+++ b/src/remote-data/utils.ts
@@ -1,0 +1,6 @@
+export const getRemoteData = (dataSourceName: string, pluginName: string) => fetch(`/api/plugin/${pluginName}/${dataSourceName}/`, {
+  credentials: 'include',
+  headers: {
+    'x-session-token': new URLSearchParams(window.location.search).get('sessionToken') ?? '',
+  },
+});


### PR DESCRIPTION
### What does this PR do?

Implemented `getRemoteData` integration with the new plugin-server architecture.

### Motivation

Make integration with LMS (fetch their data)

### More

To test simply configure the dataResource name in the manifest and then its endpoint in the URL meta parameter that goes in the create request. The manifest would look like:

```json
{
  // ...rest of manifest configuration
  "remoteDataSources": [
      {
          "name": "allUsers",
          "url": "${meta_pluginSettingsUserInformation}",
          "fetchMode": "onMeetingCreate",
          "permissions": ["moderator", "viewer"]
      }
  ]
}
```

Then when creating the meeting send the following parameters along, adjusting to your needs and resources:

```
meta_pluginSettingsUserInformation=https://<your-external-source-with-your-authentication>/api/users
pluginsManifests=[{"url": "http://<domain-of-your-manifest>/your-plugin/manifest.json"}]
```

