### PR TITLE
feat(plugins): Notification API support for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,8 @@ One other thing is that the type of the return is precisely the same type requir
   - close: this function will close the presentation area content automatically;
 - conference:
   - setSpeakerLevel: this function will set the speaker volume level(audio output) of the conference to a certain number between 0 and 1;
+- notification:
+  - send: This function will send a notification for the client to render, keep in mind that it's only client-side. Should you want it to be rendered in multiple clients, use this with a data-channel;
 - user-status:
   - setAwayStatus: this function will set the away status of the user to a certain status;
 

--- a/samples/sample-action-button-dropdown-plugin/src/components/sample-action-button-dropdown-plugin-item/component.tsx
+++ b/samples/sample-action-button-dropdown-plugin/src/components/sample-action-button-dropdown-plugin-item/component.tsx
@@ -13,6 +13,7 @@ import {
   LayoutPresentatioAreaUiDataNames,
   UiLayouts,
   pluginLogger,
+  NotificationTypeUiCommand,
 } from 'bigbluebutton-html-plugin-sdk';
 import * as ReactDOM from 'react-dom/client';
 import { IsMeetingBreakoutGraphqlResponse, SampleActionButtonDropdownPluginProps } from './types';
@@ -42,6 +43,21 @@ function SampleActionButtonDropdownPlugin(
 
   const { data: isMeetingBreakoutFromGraphql } = pluginApi.useCustomSubscription<
   IsMeetingBreakoutGraphqlResponse>(IS_MEETING_BREAKOUT);
+
+  useEffect(() => {
+    pluginApi.uiCommands.notification.send({
+      message: 'Notification message',
+      icon: 'presentation',
+      type: NotificationTypeUiCommand.INFO,
+      options: {
+        // helpLabel: 'teste help label', // this is not necessary
+        // helpLink: 'teste help link',
+        autoClose: 20000,
+      },
+      content: 'Content of my notification',
+      small: false,
+    });
+  }, []);
 
   useEffect(() => {
     pluginLogger.info('isMeetingBreakout data: ', isMeetingBreakoutFromGraphql?.meeting);

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,8 @@ export * from './ui-data-hooks';
 
 export * from './server-commands';
 
+export * from './ui-commands';
+
 export * from './core';
 
 export * from './utils';

--- a/src/ui-commands/commands.ts
+++ b/src/ui-commands/commands.ts
@@ -4,6 +4,7 @@ import { sidekickOptionsContainer } from './sidekick-options-container/commands'
 import { presentationArea } from './presentation-area/commands';
 import { userStatus } from './user-status/commands';
 import { conference } from './conference/commands';
+import { notification } from './notification/commands';
 
 export const uiCommands = {
   chat,
@@ -12,4 +13,5 @@ export const uiCommands = {
   presentationArea,
   userStatus,
   conference,
+  notification,
 };

--- a/src/ui-commands/index.ts
+++ b/src/ui-commands/index.ts
@@ -1,0 +1,1 @@
+export { NotificationTypeUiCommand } from './notification/enums';

--- a/src/ui-commands/notification/commands.ts
+++ b/src/ui-commands/notification/commands.ts
@@ -1,0 +1,17 @@
+import { NotificationEnum } from './enums';
+import { SendNotificationCommandArguments } from './types';
+
+export const notification = {
+  /**
+   * Sends notification to be rendered in the front-end.
+   */
+  send: (information: SendNotificationCommandArguments) => {
+    window.dispatchEvent(
+      new CustomEvent<
+        SendNotificationCommandArguments
+      >(NotificationEnum.SEND, {
+        detail: information,
+      }),
+    );
+  },
+};

--- a/src/ui-commands/notification/enums.ts
+++ b/src/ui-commands/notification/enums.ts
@@ -1,0 +1,11 @@
+export enum NotificationEnum {
+  SEND = 'SEND_NOTIFICATION',
+}
+
+export enum NotificationTypeUiCommand {
+  INFO = 'info',
+  DEFAULT = 'default',
+  WARNING = 'warning',
+  SUCCESS = 'success',
+  ERROR = 'error'
+}

--- a/src/ui-commands/notification/types.ts
+++ b/src/ui-commands/notification/types.ts
@@ -1,0 +1,20 @@
+import { NotificationTypeUiCommand } from './enums';
+
+export interface SendNotificationCommandArgumentsOptions {
+  helpLabel?: string,
+  helpLink?: string,
+  autoClose?: number, // Time, in milliseconds, to auto-close the notification
+}
+
+export interface SendNotificationCommandArguments {
+  message: string;
+  icon: string;
+  type: NotificationTypeUiCommand;
+  options?: SendNotificationCommandArgumentsOptions;
+  content?: string;
+  small?: boolean;
+}
+
+export interface UiCommandsNotificationObject {
+  send: (information: SendNotificationCommandArguments) => void;
+}

--- a/src/ui-commands/types.ts
+++ b/src/ui-commands/types.ts
@@ -4,6 +4,7 @@ import { UiCommandsSidekickOptionsContainerObject } from './sidekick-options-con
 import { UiCommandsPresentationAreaObject } from './presentation-area/types';
 import { UiCommandsUserStatusObject } from './user-status/types';
 import { UiCommandsConferenceObject } from './conference/types';
+import { UiCommandsNotificationObject } from './notification/types';
 
 export interface UiCommands {
   chat: UiCommandsChatObject;
@@ -12,4 +13,5 @@ export interface UiCommands {
   presentationArea: UiCommandsPresentationAreaObject;
   userStatus: UiCommandsUserStatusObject;
   conference: UiCommandsConferenceObject;
+  notification: UiCommandsNotificationObject;
 }


### PR DESCRIPTION
### What does this PR do?

It allows the user to send a notification client-side. If, on the other hand, a developer wants to make it so that everyone receives a notification at the same time,  they can easily do it with the help of a data-channel.

### How to test

I, myself, used the `sample-action-button-dropdown` to test it. I already left the necessary code change there to make it easier to test. But, one can simply use this API in whatever plugin they want.

### More

See demo, below:


https://github.com/user-attachments/assets/628fbca2-0c5c-416a-86ac-68ce6bc57fdd


We can always change the UI, of course, but mind that this PR doesn't aim to change the structure of the notification itself, it simply wants to simply open the possibility for a plugin to send a notification in the current notify structure.

But again, this is arguable, so if you have a suggestion, please comment down below.

Closely related to https://github.com/bigbluebutton/bigbluebutton/pull/21625