### PR TITLE
feat(plugin): asset persistence

### DIFF
--- a/samples/sample-action-button-dropdown-plugin/manifest.json
+++ b/samples/sample-action-button-dropdown-plugin/manifest.json
@@ -5,7 +5,7 @@
   "localesBaseUrl": "https://cdn.dominio.com/pluginabc/",
   "assetPersistence": {
     "enabled": true,
-    "maxFileSize": 10,
-    "maxUploadSizePerUser": 100
+    "maxFileSize": 10000000,
+    "maxUploadSizePerUser": 100000000
   }
 }

--- a/samples/sample-action-button-dropdown-plugin/manifest.json
+++ b/samples/sample-action-button-dropdown-plugin/manifest.json
@@ -3,5 +3,9 @@
   "name": "SampleActionButtonDropdownPlugin",
   "javascriptEntrypointUrl": "SampleActionButtonDropdownPlugin.js",
   "localesBaseUrl": "https://cdn.dominio.com/pluginabc/",
-  "enabledForBreakoutRooms": true
+  "assetPersistence": {
+    "enabled": true,
+    "maxFileSize": 10,
+    "maxUploadSizePerUser": 100
+  }
 }

--- a/samples/sample-action-button-dropdown-plugin/src/components/sample-action-button-dropdown-plugin-item/component.tsx
+++ b/samples/sample-action-button-dropdown-plugin/src/components/sample-action-button-dropdown-plugin-item/component.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { useState, useEffect } from 'react';
+import { AssetType } from 'bigbluebutton-html-plugin-sdk/dist/cjs/asset-persistence/enums';
 import * as ReactModal from 'react-modal';
 import './style.css';
 
@@ -45,13 +46,22 @@ function SampleActionButtonDropdownPlugin(
   IsMeetingBreakoutGraphqlResponse>(IS_MEETING_BREAKOUT);
 
   useEffect(() => {
+    // This line is commented once it will upload a
+    // PDF everytime you enter a meeting
+    // (if you have presenter role).
+    // Uncomment them to test this feature!
+    pluginApi.persistAsset(
+      'https://pdfobject.com/pdf/sample.pdf',
+      AssetType.PRESENTATION,
+      'my-presentation.pdf',
+    );
     pluginApi.uiCommands.notification.send({
       message: 'Notification message',
       icon: 'presentation',
       type: NotificationTypeUiCommand.INFO,
       options: {
-        // helpLabel: 'teste help label', // this is not necessary
-        // helpLink: 'teste help link',
+        // helpLabel: 'test help label', // this is not necessary
+        // helpLink: 'test help link',
         autoClose: 20000,
       },
       content: 'Content of my notification',

--- a/src/asset-persistence/enums.ts
+++ b/src/asset-persistence/enums.ts
@@ -1,0 +1,7 @@
+export enum AssetPersistenceEvents {
+  ASSET_PERSISTED = 'PLUGIN_ASSET_PERSISTED',
+}
+
+export enum AssetType {
+  PRESENTATION = 'PLUGIN_ASSET_PERSISTENCE_TYPE_PRESENTATION'
+}

--- a/src/asset-persistence/hook.ts
+++ b/src/asset-persistence/hook.ts
@@ -1,0 +1,23 @@
+import {
+  AssetPersistenceDetails,
+} from './types';
+import { AssetPersistenceEvents, AssetType } from './enums';
+
+export const persistAssetFunctionWrapper = (
+  pluginName: string,
+  assetUrl: string,
+  typeOfAsset: AssetType,
+  assetName?: string,
+) => {
+  window.dispatchEvent(
+    new CustomEvent<
+    AssetPersistenceDetails>(AssetPersistenceEvents.ASSET_PERSISTED, {
+      detail: {
+        pluginName,
+        assetUrl,
+        typeOfAsset,
+        assetName,
+      },
+    }),
+  );
+};

--- a/src/asset-persistence/types.ts
+++ b/src/asset-persistence/types.ts
@@ -1,0 +1,14 @@
+import { AssetType } from './enums';
+
+export interface AssetPersistenceDetails {
+  pluginName: string;
+  assetUrl: string;
+  typeOfAsset: AssetType;
+  assetName?: string;
+}
+
+export type PersistAssetFunction = (
+  assetUrl: string,
+  typeOfAsset: AssetType,
+  assetName?: string,
+) => void;

--- a/src/core/api/BbbPluginSdk.ts
+++ b/src/core/api/BbbPluginSdk.ts
@@ -48,6 +48,8 @@ import { sendGenericDataForLearningAnalyticsDashboard } from '../../learning-ana
 import { GenericDataForLearningAnalyticsDashboard } from '../../learning-analytics-dashboard/types';
 import { getRemoteData } from '../../remote-data/utils';
 import { persistEventFunctionWrapper } from '../../event-persistence/hooks';
+import { persistAssetFunctionWrapper } from '../../asset-persistence/hook';
+import { AssetType } from '../../asset-persistence/enums';
 
 declare const window: PluginBrowserWindow;
 
@@ -123,6 +125,16 @@ export abstract class BbbPluginSdk {
           eventName,
           payload,
         );
+      pluginApi.persistAsset = (
+        assetUrl: string,
+        typeOfAsset: AssetType,
+        assetName?: string,
+      ) => persistAssetFunctionWrapper(
+        pluginName,
+        assetUrl,
+        typeOfAsset,
+        assetName,
+      );
     } else {
       throw new Error('Plugin name not set');
     }

--- a/src/core/api/types.ts
+++ b/src/core/api/types.ts
@@ -32,6 +32,7 @@ import { UseUserCameraDomElementsFunction } from '../../dom-element-manipulation
 import { ScreenshareHelperInterface, UserCameraHelperInterface } from '../../extensible-areas';
 import { GetDataSource } from '../../remote-data/types';
 import { PersistEventFunction } from '../../event-persistence/types';
+import { PersistAssetFunction } from '../../asset-persistence/types';
 
 // Setter Functions for the API
 export type SetPresentationToolbarItems = (presentationToolbarItem:
@@ -259,6 +260,13 @@ export interface PluginApi {
    *
    */
   persistEvent?: PersistEventFunction;
+  /**
+   * Persists assets to the current meeting, e.g.: presentation.
+   *
+   * @param payload - payload to be persisted in `events.xml`
+   *
+   */
+  persistAsset?: PersistAssetFunction;
 }
 
 export interface PluginBrowserWindow extends Window {


### PR DESCRIPTION
### What does this PR do?

It does 2 things in general:

- Creates a new feature for the plugins to use: the asset-persistence;
- Fix the MaxFileSize error that was not happening;

The second point is there just so I can properly validate if the file size of the presentation that the person is sending is not bigger than expected.

### Motivation

This will allow us to send PDFs into BBB via plugin so that new ways of uploading an h5p file can exist - this is for the h5p-plugin.

### How to test
Just use the `sample-action-button-dropdown-plugin` in the plugin-sdk repository. It will upload automatically a sample presentation.

To test the expected error, one can decrease the number in `manifest.assetPersistence.maxFileSize` to say 100, which means it allows a file with a maximum of 100 Bytes (pretty much any file you send is greater than that).

### More

See demo:

https://github.com/user-attachments/assets/585a430c-89b2-42db-b894-0feebff28cdc

Closely related to CORE PR: https://github.com/bigbluebutton/bigbluebutton/pull/21777

**There is only one feature left to implement here**
- [ ] validate maxUploadSizePerUser;

That is, the maximum file-size that a user can upload via the plugin, so that if we have 100MB for this config, the user can send 10 files of 10MB, for instance, or 20 files of 5MB, and so on.

This will be implemented once the issue https://github.com/bigbluebutton/bigbluebutton/issues/21776 is fixed, because this will introduce a new type of expected error in the presentation.
