### PR TITLE
feat(plugin): add setDisplayActionsBar ui-command

### DIFF
--- a/samples/sample-action-button-dropdown-plugin/src/components/sample-action-button-dropdown-plugin-item/component.tsx
+++ b/samples/sample-action-button-dropdown-plugin/src/components/sample-action-button-dropdown-plugin-item/component.tsx
@@ -129,6 +129,18 @@ function SampleActionButtonDropdownPlugin(
           },
         }),
         new ActionButtonDropdownOption({
+          label: 'Close actions bar for 5 seconds',
+          icon: 'copy',
+          tooltip: 'this is a button injected by plugin',
+          allowed: true,
+          onClick: () => {
+            pluginApi.uiCommands.actionsBar.setDisplayActionBar({ displayActionBar: false });
+            setTimeout(() => {
+              pluginApi.uiCommands.actionsBar.setDisplayActionBar({ displayActionBar: true });
+            }, 5000);
+          },
+        }),
+        new ActionButtonDropdownOption({
           label: showingGenericContentInPresentationArea ? 'Return previous presentation content' : 'Set different content in presentation area',
           icon: 'copy',
           tooltip: 'this is a button injected by plugin',

--- a/src/ui-commands/actions-bar/commands.ts
+++ b/src/ui-commands/actions-bar/commands.ts
@@ -1,0 +1,22 @@
+import { ActionsBarEnum } from './enums';
+import { SetDisplayActionBarCommandArguments } from './types';
+
+export const actionsBar = {
+  /**
+   * Decides whether to display the actions bar
+   *
+   * @param setSpeakerLevelCommandArgumentsthe volume to which the core will set the speaker
+   * level.
+   * Refer to {@link SetDisplayActionBarCommandArguments} to understand the argument structure.
+   */
+  setDisplayActionBar: (arg: SetDisplayActionBarCommandArguments) => {
+    const { displayActionBar } = arg;
+    window.dispatchEvent(new CustomEvent<
+      SetDisplayActionBarCommandArguments
+    >(ActionsBarEnum.SET_DISPLAY_ACTIONS_BAR, {
+      detail: {
+        displayActionBar,
+      },
+    }));
+  },
+};

--- a/src/ui-commands/actions-bar/enums.ts
+++ b/src/ui-commands/actions-bar/enums.ts
@@ -1,0 +1,3 @@
+export enum ActionsBarEnum {
+  SET_DISPLAY_ACTIONS_BAR = 'SET_DISPLAY_ACTIONS_BAR_COMMAND',
+}

--- a/src/ui-commands/actions-bar/types.ts
+++ b/src/ui-commands/actions-bar/types.ts
@@ -1,0 +1,9 @@
+export interface SetDisplayActionBarCommandArguments {
+  displayActionBar: boolean;
+}
+
+export interface UiCommandsActionsBarObject {
+  setDisplayActionBar: (
+    arg: SetDisplayActionBarCommandArguments
+  ) => void;
+}

--- a/src/ui-commands/commands.ts
+++ b/src/ui-commands/commands.ts
@@ -5,8 +5,10 @@ import { presentationArea } from './presentation-area/commands';
 import { userStatus } from './user-status/commands';
 import { conference } from './conference/commands';
 import { notification } from './notification/commands';
+import { actionsBar } from './actions-bar/commands';
 
 export const uiCommands = {
+  actionsBar,
   chat,
   externalVideo,
   sidekickOptionsContainer,

--- a/src/ui-commands/types.ts
+++ b/src/ui-commands/types.ts
@@ -5,8 +5,10 @@ import { UiCommandsPresentationAreaObject } from './presentation-area/types';
 import { UiCommandsUserStatusObject } from './user-status/types';
 import { UiCommandsConferenceObject } from './conference/types';
 import { UiCommandsNotificationObject } from './notification/types';
+import { UiCommandsActionsBarObject } from './actions-bar/types';
 
 export interface UiCommands {
+  actionsBar: UiCommandsActionsBarObject;
   chat: UiCommandsChatObject;
   externalVideo: UiCommandsExternalVideoObject;
   sidekickOptionsContainer: UiCommandsSidekickOptionsContainerObject;


### PR DESCRIPTION
### What does this PR do?

It adds the possibility to display or hide the actions-bar via UI-command.


### How to test

One can use the SampleActionButtonDropdown in the plugin-SDK to see this feature working, just like in the demo! (See **More** section)

### More

Closely related to https://github.com/bigbluebutton/bigbluebutton/pull/21859

See demo below (just a minor explanation: If the user clicks the button, the plugin sends a ui-command to first close the actions-bar, and then, after 5 seconds, it sends a ui-command again to open it since one can't reach that button again. That's why it  automatically returns, the developer has full control over it).


https://github.com/user-attachments/assets/7cdad3a1-b919-4f30-8e3b-9ad265e0ef85


