### PR TITLE
feat(plugins): add useLocaleMessage to plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,10 +188,11 @@ That being said, here are the extensible areas we have so far:
 
 Mind that no plugin will interfere into another's extensible area. So feel free to set whatever you need into a certain plugin with no worries.
 
-### Getters available through the API:
+### Auxiliar functions:
 
 - `getSessionToken`: returns the user session token located on the user's URL.
 - `getJoinUrl`: returns the join url associated with the parameters passed as an argument. Since it fetches the BigBlueButton API, this getter method is asynchronous.
+- `useLocaleMessages`: returns the messages to be used in internationalization functions (recommend to use `react-intl`, as example, refer to official plugins)
 
 ### Realtime data consumption
 

--- a/src/core/api/BbbPluginSdk.ts
+++ b/src/core/api/BbbPluginSdk.ts
@@ -48,6 +48,7 @@ import { sendGenericDataForLearningAnalyticsDashboard } from '../../learning-ana
 import { GenericDataForLearningAnalyticsDashboard } from '../../learning-analytics-dashboard/types';
 import { getRemoteData } from '../../remote-data/utils';
 import { persistEventFunctionWrapper } from '../../event-persistence/hooks';
+import useLocaleMessagesAuxiliary from '../auxiliary/plugin-information/locale-messages/useLocaleMessages';
 
 declare const window: PluginBrowserWindow;
 
@@ -123,6 +124,9 @@ export abstract class BbbPluginSdk {
           eventName,
           payload,
         );
+      pluginApi.useLocaleMessages = (
+        fetchConfigs?: RequestInit,
+      ) => useLocaleMessagesAuxiliary({ pluginApi, fetchConfigs });
     } else {
       throw new Error('Plugin name not set');
     }

--- a/src/core/api/types.ts
+++ b/src/core/api/types.ts
@@ -238,6 +238,12 @@ export interface PluginApi {
   // --- Auxiliary functions ---
   getSessionToken?: GetSessionTokenFunction;
   getJoinUrl?: GetJoinUrlFunction;
+  /**
+   * Return messages to be used in the internacionalization functions (react-intl is recommended)
+   *
+   * @param fetchConfigs - fetch configuration object for the locale files (otional,
+   * usefull in dev environments).
+   */
   useLocaleMessages?: UseLocaleMessagesFunction
   /**
    * Send data to the Learning analytics dashboard

--- a/src/core/api/types.ts
+++ b/src/core/api/types.ts
@@ -32,6 +32,7 @@ import { UseUserCameraDomElementsFunction } from '../../dom-element-manipulation
 import { ScreenshareHelperInterface, UserCameraHelperInterface } from '../../extensible-areas';
 import { GetDataSource } from '../../remote-data/types';
 import { PersistEventFunction } from '../../event-persistence/types';
+import { UseLocaleMessagesFunction } from '../auxiliary/plugin-information/locale-messages/types';
 
 // Setter Functions for the API
 export type SetPresentationToolbarItems = (presentationToolbarItem:
@@ -237,6 +238,7 @@ export interface PluginApi {
   // --- Auxiliary functions ---
   getSessionToken?: GetSessionTokenFunction;
   getJoinUrl?: GetJoinUrlFunction;
+  useLocaleMessages?: UseLocaleMessagesFunction
   /**
    * Send data to the Learning analytics dashboard
    *

--- a/src/core/auxiliary/plugin-information/locale-messages/subscriptions.ts
+++ b/src/core/auxiliary/plugin-information/locale-messages/subscriptions.ts
@@ -1,0 +1,12 @@
+const GET_PLUGIN_INFORMATION = `
+subscription GetPluginInformation {
+  plugin {
+    javascriptEntrypointIntegrity
+    javascriptEntrypointUrl
+    localesBaseUrl
+    name
+  }
+}
+`;
+
+export { GET_PLUGIN_INFORMATION };

--- a/src/core/auxiliary/plugin-information/locale-messages/types.ts
+++ b/src/core/auxiliary/plugin-information/locale-messages/types.ts
@@ -1,0 +1,32 @@
+import { PluginApi } from 'src/core/api/types';
+
+interface UseLocaleMessagesProps {
+  pluginApi: PluginApi;
+  fetchConfigs?: RequestInit;
+}
+
+interface PluginInformationResult {
+  javascriptEntrypointIntegrity: string;
+  javascriptEntrypointUrl: string;
+  localesBaseUrl: string;
+}
+
+interface GraphqlResponseWrapper {
+  plugin: PluginInformationResult[];
+}
+
+interface IntlMessages {
+  loading: boolean;
+  messages: Record<string, string>;
+  currentLocale: string;
+}
+
+type UseLocaleMessagesFunction = (fetchConfigs?: RequestInit) => IntlMessages;
+
+export {
+  UseLocaleMessagesProps,
+  PluginInformationResult,
+  GraphqlResponseWrapper,
+  IntlMessages,
+  UseLocaleMessagesFunction,
+};

--- a/src/core/auxiliary/plugin-information/locale-messages/useLocaleMessages.ts
+++ b/src/core/auxiliary/plugin-information/locale-messages/useLocaleMessages.ts
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { IntlLocaleUiDataNames } from '../../../../ui-data-hooks';
+import { pluginLogger } from '../../../../utils';
+import { GraphqlResponseWrapper, IntlMessages, UseLocaleMessagesProps } from './types';
+import { GET_PLUGIN_INFORMATION } from './subscriptions';
+
+function useLocaleMessagesAuxiliary(
+  { pluginApi, fetchConfigs }: UseLocaleMessagesProps,
+): IntlMessages {
+  const currentLocale = pluginApi.useUiData!(IntlLocaleUiDataNames.CURRENT_LOCALE, {
+    locale: 'en',
+    fallbackLocale: 'en',
+  });
+
+  const [loading, setLoading] = React.useState(true);
+  const [messages, setMessages] = React.useState<Record<string, string>>({});
+
+  const { data: pluginInformation } = pluginApi.useCustomSubscription!<GraphqlResponseWrapper>(
+    GET_PLUGIN_INFORMATION,
+  );
+
+  React.useEffect(() => {
+    if (pluginInformation && pluginInformation.plugin && currentLocale.locale) {
+      const { localesBaseUrl } = pluginInformation.plugin[0];
+      const { locale } = currentLocale;
+      const localeUrl = `${localesBaseUrl}/${locale}.json`;
+      fetch(localeUrl, fetchConfigs).then((result) => result.json()).then((localeMessages) => {
+        setLoading(false);
+        setMessages(localeMessages);
+      }).catch((err) => {
+        setLoading(false);
+        pluginLogger.error(`Something went wrong while trying to fetch ${localeUrl}: `, err);
+      });
+    }
+  }, [pluginInformation, currentLocale]);
+  return {
+    messages,
+    loading,
+    currentLocale: currentLocale.locale,
+  };
+}
+
+export default useLocaleMessagesAuxiliary;

--- a/src/data-consumption/domain/settings/plugin-settings/utils.ts
+++ b/src/data-consumption/domain/settings/plugin-settings/utils.ts
@@ -5,7 +5,7 @@ export const filterPluginSpecificSettings = (
   completeSettings: GraphqlResponseWrapper<PluginSettingsResponseFromGraphqlWrapper>,
 ) => {
   const pluginSettings = completeSettings
-    .data?.meeting_clientPluginSettings[0].settings;
+    .data?.meeting_clientPluginSettings[0]?.settings;
   return {
     ...completeSettings,
     data: pluginSettings,


### PR DESCRIPTION
### What does this PR do?

This PR adds the hook `useLocaleMessage` to the pluginApi to fetch the locale messages for the internationalization of the plugins. 

### Motivation

Add internationalization for the plugins more easily as requested in the issue https://github.com/bigbluebutton/plugin-typed-captions/issues/6

### How to test

To test this, there ar 3 PRs that work together here: This one in the CORE, the one in the SDK, mentioned ahead and the one in the typed-captions (which will be sent later on), so the 3 of them must be tested at the same time.

- First, one will have to apply the SDK manually into the plugin-typed-captions (Considering both in the correct branches);
- Run in dev mode;
- So as we are testing it with ngrok, they put some barriers there to avoid security breaches, so to properly make the testing work, do the following:

Go into the `webpack.config.js` file in the plugin, and write:
```js
headers: {
      'Access-Control-Allow-Origin': '*',
      'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, PATCH, OPTIONS',
      'Access-Control-Allow-Headers': 'X-Requested-With, content-type, Authorization, ngrok-skip-browser-warning', 
    },
```
Into the `devServer` directive (If that's not there yet).

Then into the file `src/components/main/component.tsx` search for the hook used to obtain the intl-messages that is `pluginApi.useLocaleMessages` and add the following argument to the function:

```js
{
    headers: {
      'ngrok-skip-browser-warning': 'any',
    },
  }
```

With that, the ngrok will not complain about the locale files and everything should flow normally.

### More

Closely related to the PR in the CORE https://github.com/bigbluebutton/bigbluebutton/pull/22269

See demo of this feature:


https://github.com/user-attachments/assets/2ad2d66b-4976-4ab7-9438-6a77386376b0


