### PR TITLE
fix(getJoinUrl): Fix function to get join URL for cluster setups in BBB

### DIFF
--- a/src/core/api/BbbPluginSdk.ts
+++ b/src/core/api/BbbPluginSdk.ts
@@ -85,6 +85,7 @@ export abstract class BbbPluginSdk {
     pluginApi.useMeeting = (() => useMeeting()) as UseMeetingFunction;
     pluginApi.useUsersBasicInfo = (() => useUsersBasicInfo()) as UseUsersBasicInfoFunction;
     pluginApi.useTalkingIndicator = (() => useTalkingIndicator()) as UseTalkingIndicatorFunction;
+    pluginApi.getJoinUrl = (params) => getJoinUrl(params);
     pluginApi.useLoadedChatMessages = (
       () => useLoadedChatMessages()) as UseLoadedChatMessagesFunction;
     pluginApi.useChatMessageDomElements = (
@@ -182,7 +183,6 @@ export abstract class BbbPluginSdk {
           '': () => {},
         },
         getSessionToken: () => getSessionToken(),
-        getJoinUrl: (params) => getJoinUrl(params),
         pluginName,
       };
     }

--- a/src/core/api/types.ts
+++ b/src/core/api/types.ts
@@ -269,6 +269,15 @@ export interface PluginApi {
   persistEvent?: PersistEventFunction;
 }
 
+export interface MeetingClientSettings {
+  public: {
+    app: {
+      bbbWebBase: string;
+    }
+  }
+}
+
 export interface PluginBrowserWindow extends Window {
   bbb_plugins: { [key: string]: PluginApi};
+  meetingClientSettings?: MeetingClientSettings;
 }

--- a/src/core/auxiliary/join-url/getter.ts
+++ b/src/core/auxiliary/join-url/getter.ts
@@ -1,4 +1,7 @@
+import { PluginBrowserWindow } from 'src/core/api/types';
 import { getSessionToken } from '../session-token/getter';
+
+declare const window: PluginBrowserWindow;
 
 function objectToUrlParameters(parameters: {[key: string]: string}): string {
   const queryString = Object.entries(parameters)
@@ -9,8 +12,11 @@ function objectToUrlParameters(parameters: {[key: string]: string}): string {
 
 export async function getJoinUrl(parameters: {[key: string]: string}): Promise<string> {
   const urlParameters = objectToUrlParameters(parameters);
-  const url = `${document.location.origin}/bigbluebutton/api/getJoinUrl?sessionToken=${getSessionToken()}&${urlParameters}`;
-  const response = await fetch(url);
+  const baseUrl = window.meetingClientSettings?.public.app.bbbWebBase || '/bigbluebutton';
+  const url = `${baseUrl}/api/getJoinUrl?sessionToken=${getSessionToken()}&${urlParameters}`;
+  const response = await fetch(url, {
+    credentials: 'include',
+  });
   const responseUrl = await response.json();
   return responseUrl.response.url as string;
 }


### PR DESCRIPTION
### What does this PR do?

This PR changes the `getJoinUrl` function so now it is based on the `bbbWebBase` setting.
One other minor change: Moved this function to be initialized in the `initialize` method and not the getPlugins method. It won't change much in terms of practical behaviour, but it makes the development a lot easier.


### Closes Issue(s)
Closes #54 


### Motivation

This fix is mostly due to a problem in the `plugin-session-share`. No changes needed there, though.