### PR TITLE
feat(plugins): Add support for the plugin to unmount on meeting end

### DIFF
--- a/src/core/api/BbbPluginSdk.ts
+++ b/src/core/api/BbbPluginSdk.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import { useEffect } from 'react';
+import useShouldUnmountPlugin from '../auxiliary/plugin-unmount/hook';
 import { UseLoadedUserListFunction } from '../../data-consumption/domain/users/loaded-user-list/types';
 import { UseCurrentUserFunction } from '../../data-consumption/domain/users/current-user/types';
 import {
@@ -97,6 +98,7 @@ export abstract class BbbPluginSdk {
     pluginApi.uiCommands = uiCommands;
     pluginApi.useUiData = useUiData;
     const pluginName = pluginApi?.pluginName;
+    pluginApi.useShouldUnmountPlugin = useShouldUnmountPlugin;
     if (pluginName) {
       pluginApi.useDataChannel = ((
         channelName: string,

--- a/src/core/api/types.ts
+++ b/src/core/api/types.ts
@@ -33,6 +33,7 @@ import { ScreenshareHelperInterface, UserCameraHelperInterface } from '../../ext
 import { GetDataSource } from '../../remote-data/types';
 import { PersistEventFunction } from '../../event-persistence/types';
 import { UseLocaleMessagesFunction } from '../auxiliary/plugin-information/locale-messages/types';
+import { UseShouldUnmountPluginFunction } from '../auxiliary/plugin-unmount/types';
 
 // Setter Functions for the API
 export type SetPresentationToolbarItems = (presentationToolbarItem:
@@ -167,7 +168,7 @@ export interface PluginApi {
    *
    */
   usePluginSettings?: UsePluginSettingsFunction;
-    /**
+  /**
    * Returns an object containing a list user-voice with the main properties of that object,
    * that being talking (boolean), startTime (number), muted (boolean) and userId (string).
    *
@@ -175,6 +176,16 @@ export interface PluginApi {
    *
    */
   useTalkingIndicator?: UseTalkingIndicatorFunction;
+  /**
+   * Returns a boolean telling if the plugin should be unmounted or not based on the mounting
+   * of the meeting. This means that if the meeting end or the user is ejected, this will
+   * tell that the plugin should not be mounted and it's reversable: if the meeting is
+   * mounted again, it will update.
+   *
+   * @returns boolean
+   *
+   */
+  useShouldUnmountPlugin?: UseShouldUnmountPluginFunction;
   /**
    * Returns an object containing the data on the current presentation being displayed
    * in the presentation area, and its current page.

--- a/src/core/auxiliary/plugin-unmount/hook.ts
+++ b/src/core/auxiliary/plugin-unmount/hook.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+import { HookEvents } from '../../enum';
+import { HookEventWrapper, UpdatedEventDetails } from '../../types';
+import { MeetingStatusData } from './types';
+
+const useShouldUnmountPlugin = () => {
+  const [shouldUnmountPlugin, setShouldUnmountPlugin] = useState(false);
+
+  const handleMeetingStatusChange: EventListener = ((
+    customEvent: HookEventWrapper<MeetingStatusData>,
+  ) => {
+    const eventDetail: UpdatedEventDetails<MeetingStatusData> = (
+      customEvent.detail as UpdatedEventDetails<MeetingStatusData>);
+    setShouldUnmountPlugin(!eventDetail.data.renderMeeting);
+  }) as EventListener;
+
+  useEffect(() => {
+    window.addEventListener(HookEvents.BBB_CORE_UPDATED_MEETING_STATUS, handleMeetingStatusChange);
+    return () => {
+      window.removeEventListener(
+        HookEvents.BBB_CORE_UPDATED_MEETING_STATUS,
+        handleMeetingStatusChange,
+      );
+    };
+  }, []);
+
+  return shouldUnmountPlugin;
+};
+
+export default useShouldUnmountPlugin;

--- a/src/core/auxiliary/plugin-unmount/hook.ts
+++ b/src/core/auxiliary/plugin-unmount/hook.ts
@@ -11,7 +11,7 @@ const useShouldUnmountPlugin = () => {
   ) => {
     const eventDetail: UpdatedEventDetails<MeetingStatusData> = (
       customEvent.detail as UpdatedEventDetails<MeetingStatusData>);
-    setShouldUnmountPlugin(!eventDetail.data.renderMeeting);
+    setShouldUnmountPlugin(!eventDetail.data.userCurrentlyInMeeting);
   }) as EventListener;
 
   useEffect(() => {

--- a/src/core/auxiliary/plugin-unmount/types.ts
+++ b/src/core/auxiliary/plugin-unmount/types.ts
@@ -1,5 +1,5 @@
 export interface MeetingStatusData {
-  renderMeeting: boolean;
+  userCurrentlyInMeeting: boolean;
 }
 
 export type UseShouldUnmountPluginFunction = () => boolean;

--- a/src/core/auxiliary/plugin-unmount/types.ts
+++ b/src/core/auxiliary/plugin-unmount/types.ts
@@ -1,0 +1,5 @@
+export interface MeetingStatusData {
+  renderMeeting: boolean;
+}
+
+export type UseShouldUnmountPluginFunction = () => boolean;

--- a/src/core/enum.ts
+++ b/src/core/enum.ts
@@ -4,6 +4,7 @@ import { DataConsumptionHooks } from '../data-consumption/enums';
 
 export enum HookEvents {
   BBB_CORE_SENT_NEW_DATA = 'BBB_CORE_SENT_NEW_DATA',
+  BBB_CORE_UPDATED_MEETING_STATUS = 'BBB_CORE_UPDATED_MEETING_STATUS',
   /**
    * PLUGIN_SENT_CHANGES_TO_BBB_CORE is used to:
    *  - Comunicate that the subscription has changed for the dom-element-manipulation hook;
@@ -14,4 +15,7 @@ export enum HookEvents {
   PLUGIN_UNSUBSCRIBED_FROM_BBB_CORE = 'PLUGIN_UNSUBSCRIBED_FROM_BBB_CORE',
 }
 
-export type Hooks = DataConsumptionHooks | DataChannelHooks | DomElementManipulationHooks;
+export const GENERIC_HOOK_PLUGIN = 'GENERIC_HOOK_PLUGIN';
+
+export type Hooks = DataConsumptionHooks | DataChannelHooks
+| DomElementManipulationHooks | typeof GENERIC_HOOK_PLUGIN;

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,3 +1,5 @@
 export { BbbPluginSdk } from './api/BbbPluginSdk';
 export { PluginApi } from './api/types';
 export { GraphqlResponseWrapper } from './types';
+export { GENERIC_HOOK_PLUGIN } from './enum';
+export { MeetingStatusData } from './auxiliary/plugin-unmount/types';

--- a/src/data-consumption/domain/meeting/from-core/hooks.ts
+++ b/src/data-consumption/domain/meeting/from-core/hooks.ts
@@ -3,7 +3,7 @@ import { createDataConsumptionHook } from '../../../factory/hookCreator';
 import { Meeting } from './types';
 
 export const useMeeting = () => createDataConsumptionHook<
-  Meeting[]
+  Meeting
 >(
   DataConsumptionHooks.MEETING,
 );

--- a/src/data-consumption/domain/meeting/from-core/types.ts
+++ b/src/data-consumption/domain/meeting/from-core/types.ts
@@ -6,4 +6,4 @@ export interface Meeting {
   loginUrl?: string;
 }
 
-export type UseMeetingFunction = () => GraphqlResponseWrapper<Meeting[]>;
+export type UseMeetingFunction = () => GraphqlResponseWrapper<Meeting>;


### PR DESCRIPTION
### What does this PR do?

This PR basically creates a way for the plugin to decide whether to unmount when the meeting is ended or the user is ejected.


### Motivation

This PR fixes the problem where the pick-random-user modal continues open when meeting terminates (if it was open before).

A subsequent PR is going to be sent to the pick-random-user plugin repo implementing this function.

It's worth mentioning that if, for any reason, the plugin dev doesn't want to terminate the plugin once the meeting is over, that's still possible, once this function is not even mandatory. 

### How to test

Use this branch to test the pick-random-user:
- Open the modal to pick another user;
- End the meeting via API call to bbb-web.


### More
Closely related to CORE PR https://github.com/bigbluebutton/bigbluebutton/pull/22671
Closely related to Plugin PR: https://github.com/bigbluebutton/plugin-pick-random-user/pull/31

See demo ahead:

https://github.com/user-attachments/assets/8d048d15-bbfe-4468-8d87-f51b8212144b


