### PR TITLE
feat: add support for custom svg for actions bar buttons

### DIFF
--- a/samples/sample-actions-bar-plugin/src/sample-actions-bar-plugin/component.tsx
+++ b/samples/sample-actions-bar-plugin/src/sample-actions-bar-plugin/component.tsx
@@ -27,14 +27,16 @@ function SampleActionsBarPlugin({
     const buttonToUserListItem:
       // Sample of a button that uses a custom SVG for the button.
       ActionsBarInterface = new ActionsBarButton({
-        icon: (
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-cctv-icon lucide-cctv">
-            <path d="M16.75 12h3.632a1 1 0 0 1 .894 1.447l-2.034 4.069a1 1 0 0 1-1.708.134l-2.124-2.97" />
-            <path d="M17.106 9.053a1 1 0 0 1 .447 1.341l-3.106 6.211a1 1 0 0 1-1.342.447L3.61 12.3a2.92 2.92 0 0 1-1.3-3.91L3.69 5.6a2.92 2.92 0 0 1 3.92-1.3z" />
-            <path d="M2 19h3.76a2 2 0 0 0 1.8-1.1L9 15" />
-            <path d="M2 21v-4" />
-            <path d="M7 9h.01" />
-          </svg>) as React.SVGProps<SVGSVGElement>,
+        icon: {
+          svgContent: (
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-cctv-icon lucide-cctv">
+              <path d="M16.75 12h3.632a1 1 0 0 1 .894 1.447l-2.034 4.069a1 1 0 0 1-1.708.134l-2.124-2.97" />
+              <path d="M17.106 9.053a1 1 0 0 1 .447 1.341l-3.106 6.211a1 1 0 0 1-1.342.447L3.61 12.3a2.92 2.92 0 0 1-1.3-3.91L3.69 5.6a2.92 2.92 0 0 1 3.92-1.3z" />
+              <path d="M2 19h3.76a2 2 0 0 0 1.8-1.1L9 15" />
+              <path d="M2 21v-4" />
+              <path d="M7 9h.01" />
+            </svg>) as React.SVGProps<SVGSVGElement>,
+        },
         tooltip: 'This will log on the console.',
         onClick: () => {
           pluginLogger.info('The actions bar button from plugin was clicked');

--- a/samples/sample-actions-bar-plugin/src/sample-actions-bar-plugin/component.tsx
+++ b/samples/sample-actions-bar-plugin/src/sample-actions-bar-plugin/component.tsx
@@ -25,8 +25,17 @@ function SampleActionsBarPlugin({
 
   useEffect(() => {
     const buttonToUserListItem:
+      // Sample of a button that uses a custom SVG for the button.
       ActionsBarInterface = new ActionsBarButton({
-        icon: 'user',
+        icon: null,
+        customIconSvg: (
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-cctv-icon lucide-cctv">
+            <path d="M16.75 12h3.632a1 1 0 0 1 .894 1.447l-2.034 4.069a1 1 0 0 1-1.708.134l-2.124-2.97" />
+            <path d="M17.106 9.053a1 1 0 0 1 .447 1.341l-3.106 6.211a1 1 0 0 1-1.342.447L3.61 12.3a2.92 2.92 0 0 1-1.3-3.91L3.69 5.6a2.92 2.92 0 0 1 3.92-1.3z" />
+            <path d="M2 19h3.76a2 2 0 0 0 1.8-1.1L9 15" />
+            <path d="M2 21v-4" />
+            <path d="M7 9h.01" />
+          </svg>) as React.SVGProps<SVGSVGElement>,
         tooltip: 'This will log on the console.',
         onClick: () => {
           pluginLogger.info('The actions bar button from plugin was clicked');

--- a/samples/sample-actions-bar-plugin/src/sample-actions-bar-plugin/component.tsx
+++ b/samples/sample-actions-bar-plugin/src/sample-actions-bar-plugin/component.tsx
@@ -27,8 +27,7 @@ function SampleActionsBarPlugin({
     const buttonToUserListItem:
       // Sample of a button that uses a custom SVG for the button.
       ActionsBarInterface = new ActionsBarButton({
-        icon: null,
-        customIconSvg: (
+        icon: (
           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-cctv-icon lucide-cctv">
             <path d="M16.75 12h3.632a1 1 0 0 1 .894 1.447l-2.034 4.069a1 1 0 0 1-1.708.134l-2.124-2.97" />
             <path d="M17.106 9.053a1 1 0 0 1 .447 1.341l-3.106 6.211a1 1 0 0 1-1.342.447L3.61 12.3a2.92 2.92 0 0 1-1.3-3.91L3.69 5.6a2.92 2.92 0 0 1 3.92-1.3z" />

--- a/src/extensible-areas/actions-bar-item/component.ts
+++ b/src/extensible-areas/actions-bar-item/component.ts
@@ -36,9 +36,7 @@ class ActionsBarItem implements ActionsBarInterface {
 }
 
 export class ActionsBarButton extends ActionsBarItem {
-  icon: string;
-
-  customIconSvg?: React.SVGProps<SVGSVGElement>;
+  icon: string | React.SVGProps<SVGSVGElement>;
 
   tooltip: string;
 
@@ -48,8 +46,8 @@ export class ActionsBarButton extends ActionsBarItem {
    * Returns object to be used in the setter for action bar. In this case,
    * a button.
    *
-   * @param icon - icon to be used in the button for the action bar (takes priority)
-   * @param customIconSvg - svg to be used in the button icon for the action bar (not required)
+   * @param icon - icon to be used in the button for the action bar - it can be the iconName
+   * from BigbBlueButton or an svg
    * @param tooltip - tooltip to be displayed when hovering the button
    * @param onClick - function to be called when clicking the button
    * @param position - position that this button will be displayed, see {@link ActionsBarPosition}
@@ -57,11 +55,10 @@ export class ActionsBarButton extends ActionsBarItem {
    * @returns Object that will be interpreted by the core of Bigbluebutton (HTML5)
    */
   constructor({
-    id, icon = '', customIconSvg, tooltip = '', onClick = () => {}, position = ActionsBarPosition.RIGHT,
+    id, icon = '', tooltip = '', onClick = () => {}, position = ActionsBarPosition.RIGHT,
   }: ActionsBarButtonProps) {
     super({ id, type: ActionsBarItemType.BUTTON, position });
     this.icon = icon;
-    this.customIconSvg = customIconSvg;
     this.tooltip = tooltip;
     this.onClick = onClick;
   }

--- a/src/extensible-areas/actions-bar-item/component.ts
+++ b/src/extensible-areas/actions-bar-item/component.ts
@@ -38,6 +38,8 @@ class ActionsBarItem implements ActionsBarInterface {
 export class ActionsBarButton extends ActionsBarItem {
   icon: string;
 
+  customIconSvg?: React.SVGProps<SVGSVGElement>;
+
   tooltip: string;
 
   onClick: () => void;
@@ -46,7 +48,8 @@ export class ActionsBarButton extends ActionsBarItem {
    * Returns object to be used in the setter for action bar. In this case,
    * a button.
    *
-   * @param icon - icon to be used in the button for the action bar
+   * @param icon - icon to be used in the button for the action bar (takes priority)
+   * @param customIconSvg - svg to be used in the button icon for the action bar (not required)
    * @param tooltip - tooltip to be displayed when hovering the button
    * @param onClick - function to be called when clicking the button
    * @param position - position that this button will be displayed, see {@link ActionsBarPosition}
@@ -54,10 +57,11 @@ export class ActionsBarButton extends ActionsBarItem {
    * @returns Object that will be interpreted by the core of Bigbluebutton (HTML5)
    */
   constructor({
-    id, icon = '', tooltip = '', onClick = () => {}, position = ActionsBarPosition.RIGHT,
+    id, icon = '', customIconSvg, tooltip = '', onClick = () => {}, position = ActionsBarPosition.RIGHT,
   }: ActionsBarButtonProps) {
     super({ id, type: ActionsBarItemType.BUTTON, position });
     this.icon = icon;
+    this.customIconSvg = customIconSvg;
     this.tooltip = tooltip;
     this.onClick = onClick;
   }

--- a/src/extensible-areas/actions-bar-item/component.ts
+++ b/src/extensible-areas/actions-bar-item/component.ts
@@ -9,6 +9,7 @@ import {
   SelectOption,
   ToggleGroupOption,
   ActionsBarToggleGroupProps,
+  ActionsBarIconType,
 } from './types';
 
 // ActionsBar Extensible Area
@@ -36,7 +37,7 @@ class ActionsBarItem implements ActionsBarInterface {
 }
 
 export class ActionsBarButton extends ActionsBarItem {
-  icon: string | React.SVGProps<SVGSVGElement>;
+  icon: ActionsBarIconType;
 
   tooltip: string;
 
@@ -55,7 +56,7 @@ export class ActionsBarButton extends ActionsBarItem {
    * @returns Object that will be interpreted by the core of Bigbluebutton (HTML5)
    */
   constructor({
-    id, icon = '', tooltip = '', onClick = () => {}, position = ActionsBarPosition.RIGHT,
+    id, icon, tooltip = '', onClick = () => {}, position = ActionsBarPosition.RIGHT,
   }: ActionsBarButtonProps) {
     super({ id, type: ActionsBarItemType.BUTTON, position });
     this.icon = icon;

--- a/src/extensible-areas/actions-bar-item/types.ts
+++ b/src/extensible-areas/actions-bar-item/types.ts
@@ -15,9 +15,22 @@ export interface ActionsBarItemProps {
   type: ActionsBarItemType;
 }
 
+export interface ActionsBarButtonIconSvg {
+  svgContent: React.SVGProps<SVGSVGElement>;
+}
+
+export interface ActionsBarButtonIconName {
+  /**
+   * Default icon name defined by BBB (see options there).
+   */
+  iconName: string;
+}
+
+export type ActionsBarIconType = ActionsBarButtonIconSvg | ActionsBarButtonIconName
+
 export interface ActionsBarButtonProps {
   id?: string;
-  icon: string | React.SVGProps<SVGSVGElement>;
+  icon: ActionsBarIconType;
   tooltip: string;
   position: ActionsBarPosition;
   onClick: () => void;

--- a/src/extensible-areas/actions-bar-item/types.ts
+++ b/src/extensible-areas/actions-bar-item/types.ts
@@ -17,8 +17,7 @@ export interface ActionsBarItemProps {
 
 export interface ActionsBarButtonProps {
   id?: string;
-  icon: string;
-  customIconSvg?: React.SVGProps<SVGSVGElement>;
+  icon: string | React.SVGProps<SVGSVGElement>;
   tooltip: string;
   position: ActionsBarPosition;
   onClick: () => void;

--- a/src/extensible-areas/actions-bar-item/types.ts
+++ b/src/extensible-areas/actions-bar-item/types.ts
@@ -18,6 +18,7 @@ export interface ActionsBarItemProps {
 export interface ActionsBarButtonProps {
   id?: string;
   icon: string;
+  customIconSvg?: React.SVGProps<SVGSVGElement>;
   tooltip: string;
   position: ActionsBarPosition;
   onClick: () => void;


### PR DESCRIPTION
### What does this PR do?

It adds support for a custom svg icon on an actions bar button.

### Motivation

Add more flexibility for the plugin developer to choose an icon for that area. It can be extended for other areas as well in further PRs.

### How to test:

I'd recommend to use the sample plugin `sample-actions-bar-plugin`. Or just add the following snippet to your own plugin:

```ts
new ActionsBarButton({
        icon: {
          svgContent: (
            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-cctv-icon lucide-cctv">
              <path d="M16.75 12h3.632a1 1 0 0 1 .894 1.447l-2.034 4.069a1 1 0 0 1-1.708.134l-2.124-2.97" />
              <path d="M17.106 9.053a1 1 0 0 1 .447 1.341l-3.106 6.211a1 1 0 0 1-1.342.447L3.61 12.3a2.92 2.92 0 0 1-1.3-3.91L3.69 5.6a2.92 2.92 0 0 1 3.92-1.3z" />
              <path d="M2 19h3.76a2 2 0 0 0 1.8-1.1L9 15" />
              <path d="M2 21v-4" />
              <path d="M7 9h.01" />
            </svg>) as React.SVGProps<SVGSVGElement>,
        },
        tooltip: 'This will log on the console.',
        onClick: () => {
          pluginLogger.info('The actions bar button from plugin was clicked');
        },
        position: ActionsBarPosition.RIGHT,
      });
```

### More

Closely related to PR https://github.com/bigbluebutton/bigbluebutton/pull/22923

See screenshot ahead:

![image](https://github.com/user-attachments/assets/41f142b5-f1f2-48c7-8adb-037b3671e64a)

