### PR TITLE
doc: Add a guide on how to develop a new feature in the SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,13 +326,13 @@ Here is as complete `manifet.json` example with all possible configurations:
 
 ## Developing the SDK
 
-Now that you have a broad vision of how the plugins work, let's take a look on how to develop the SDK. 
+Now that you have a broad understanding of how the plugins work, let’s take a look at how to develop the SDK.
 
-**Motivation:** One can build a new feature to be used later on their plugin; Fix an error; Fix a wrong behavior in a feature, etc.
+**Motivation:** You might want to add a new feature to be used in a plugin, fix a bug, or correct an unexpected behavior in an existing feature.
 
-### Picturing the architecture
+### Understanding the Architecture
 
-First of all, here is a brief overview of the `bigbluebutton-html-plugin-sdk` relationship with the other components previous to any changes one could do (We are shortening the sdk's name from `bigbluebutton-html-plugin-sdk` to `plugin-sdk` and the `bigbluebutton-html5` to `bbb-html5`).
+Before making any changes, here's a brief overview of how `bigbluebutton-html-plugin-sdk` interacts with other components. From here on, we'll refer to `bigbluebutton-html-plugin-sdk` as `plugin-sdk` and `bigbluebutton-html5` as `bbb-html5`.
 
 ```mermaid
 graph
@@ -357,19 +357,19 @@ graph
   HTML5 --> Plugin
 ```
 
-Note that, for now, the `html5` has its own `node_modules` that imports the `plugin-sdk` version specified in the `package.json` (which in our case is the `0.0.73` just as an example) the same goes to the plugin we are developing. It's worth mentioning that the latex
+As shown above, both `bbb-html5` and the plugin being developed have their own `node_modules`, each importing the version of `plugin-sdk` specified in their respective `package.json` files (in this example, `v0.0.73`).
 
-Once the developer made a change to the `plugin-sdk` adding a new `ui-command`, for example, they will have to do the following (which will be better explained ahead):
+Once you’ve made a change to `plugin-sdk`—for example, by adding a new `ui-command`—you’ll need to:
 
-1. build the SDK;
-2. Publish the SDK to both the plugin that will use it and the `html5`;
+1. Build the SDK;
+2. Publish the SDK to both the plugin and `bbb-html5`.
 
-The end result that will look something like: 
+After that, the architecture will look like this:
 
 ```mermaid
 graph TB
   %% SDK Box
-  subgraph SDK["bbb-plugin-sdk (built)"]
+  subgraph SDK["plugin-sdk (built)"]
     A1[new-ui-command]
   end
 
@@ -394,44 +394,46 @@ graph TB
   B1 & C1 --> SDK 
 ```
 
-Now, one can see that the `node_modules` (from both `html5` and `plugin`) does not have its own `plugin-sdk`, but rather point to the new built version of the SDK containing the changes developed by the developer.
+Now, instead of each having their own version, both `bbb-html5` and the plugin point to the newly built version of `plugin-sdk`, which includes your changes.
 
-### Building scripts
+### Building the SDK
 
-As we saw in the previous section, right after the developer made the changes to the `plugin-sdk`, we need to follow the instructions:
+As outlined above, once your changes to the `plugin-sdk` are complete, follow these steps:
 
-**1. Install and build the SDK (adjust the command to your SDK directory):**
+**1. Install dependencies and build the SDK (adjust the path to your SDK directory):**
 
 ```bash
-cd ~/bigbluebutton-html-plugin-sdk/
-npm i
+cd ~/dev/bigbluebutton-html-plugin-sdk/
+npm install
 npm run build
 ```
 
-**2. publish the SDK to the HTML5:**
+**2. Publish the SDK to `bbb-html5`:**
 
 ```bash
-./publish-to-project-folder.sh ~/dev/bigbluebuton/bigbluebutton-html5
+./scripts/publish-to-project-folder.sh ~/dev/bigbluebutton/bigbluebutton-html5
 ```
 
 **3. Publish the SDK to the plugin you want to test:**
 
-Mind that we often use the samples plugin to test a new developed feature, so we would do:
+We often use the sample plugins to test new features. To do that, run:
 
 ```bash
-./publish-to-samples.sh
+./scripts/publish-to-samples.sh
 ```
 
-or you can publish to a specific plugin like the pick-random-user and run (change the directory to fit your needs):
+Alternatively, to publish to a specific plugin (e.g., `plugin-pick-random-user`), run:
 
 ```bash
-./publish-to-project-folder.sh ~/dev/plugin-pick-random-user
+./scripts/publish-to-project-folder.sh ~/dev/plugin-pick-random-user
 ```
 
-As one can tell, the first argument of the `publish-to-project-folder.sh` script is the directory you would want to publish to.
+The first argument to the `publish-to-project-folder.sh` script is the path to the project you want to publish the SDK to.
 
 ---
 
-After doing that, we have the developed feature available to both the `html5` and the plugin of your choice to test it. For the `html5`, we normally use the window event names to add the listener anchor to some portion of the application.
+After completing these steps, the new feature is available in both `bbb-html5` and the plugin of your choice. For `bbb-html5`, you can typically use window event names to add a listener and connect the feature to a part of the core application.
 
-With the code changes in hands, it's necessary to send it to the github repository, so open a PR for both the SDK and core of BBB. We normally link them both in the `More` section like "Closely related to the PR on the CORE <link-of-the-core-pr>"
+Once the development is done, open a pull request (PR) for both the SDK and the core BBB repository. We usually link them in the “More” section like so:
+
+_Closely related to the PR on the CORE: <link-to-core-pr>_


### PR DESCRIPTION
### What does this PR do?

It adds a new section to the readme documentation to guide a developer through the development process of the SDK

### Motivation

During the summit week, some developers tried developing new features and got a bit lost in the process, this should help.

### More

See some screenshots of how it will look once merged in:

![image](https://github.com/user-attachments/assets/dc24213b-3017-4292-b3fc-0c93b48a1181)

![image](https://github.com/user-attachments/assets/ffd64930-a0bb-40d8-9352-c2d3e67543e7)

