### PR TITLE
ci: Add support for run plugin tests in BBB's CI 

### DIFF
--- a/src/data-consumption/domain/settings/plugin-settings/hooks.ts
+++ b/src/data-consumption/domain/settings/plugin-settings/hooks.ts
@@ -1,9 +1,9 @@
 import { useCustomSubscription } from '../../shared/custom-subscription/hooks';
 import { PLUGIN_SETTINGS_QUERY } from './queries';
-import { PluginSettingsResponseFromGraphqlWrapper } from './types';
+import { PluginSettingsResponseFromGraphqlWrapper, UsePluginSettingsWrapperFunction } from './types';
 import { filterPluginSpecificSettings } from './utils';
 
-export const usePluginSettings = (
+export const usePluginSettings: UsePluginSettingsWrapperFunction = (
   pluginName: string,
 ) => filterPluginSpecificSettings(useCustomSubscription<
     PluginSettingsResponseFromGraphqlWrapper>(PLUGIN_SETTINGS_QUERY, {

--- a/src/data-consumption/domain/settings/plugin-settings/types.ts
+++ b/src/data-consumption/domain/settings/plugin-settings/types.ts
@@ -13,3 +13,13 @@ export interface PluginSettingsResponseFromGraphqlWrapper {
 export type UsePluginSettingsFunction = () => GraphqlResponseWrapper<
   PluginSettingsData
 >;
+
+export type UsePluginSettingsWrapperFunction = (pluginName: string) => GraphqlResponseWrapper<
+  PluginSettingsData
+>;
+
+export type FilterPluginSpecificSettingsFunction = (
+  completeSettings: GraphqlResponseWrapper<PluginSettingsResponseFromGraphqlWrapper>,
+) => GraphqlResponseWrapper<
+  PluginSettingsData
+>

--- a/src/data-consumption/domain/settings/plugin-settings/utils.ts
+++ b/src/data-consumption/domain/settings/plugin-settings/utils.ts
@@ -1,7 +1,7 @@
 import { GraphqlResponseWrapper } from '../../../../core';
-import { PluginSettingsResponseFromGraphqlWrapper } from './types';
+import { FilterPluginSpecificSettingsFunction, PluginSettingsResponseFromGraphqlWrapper } from './types';
 
-export const filterPluginSpecificSettings = (
+export const filterPluginSpecificSettings: FilterPluginSpecificSettingsFunction = (
   completeSettings: GraphqlResponseWrapper<PluginSettingsResponseFromGraphqlWrapper>,
 ) => {
   const pluginSettings = completeSettings


### PR DESCRIPTION
### What does this PR do?

Add support for run plugin tests in BBB's CI. This basically fix the typescript issues that arise from importing a commit and building it all inside the CI. 

### Motivation

Add CI tests for plugins in BBB's repo

### More

Right after the merge of this PR, we need a new version in npmjs. (just a comment)

Closely related to https://github.com/bigbluebutton/bigbluebutton/pull/23028