### PR TITLE
fix: Fix hook useLocaleMessages to accept fallback locales.

### DIFF
--- a/src/core/auxiliary/plugin-information/locale-messages/useLocaleMessages.ts
+++ b/src/core/auxiliary/plugin-information/locale-messages/useLocaleMessages.ts
@@ -1,7 +1,8 @@
-import * as React from 'react';
+import { useEffect, useState } from 'react';
 import { IntlLocaleUiDataNames } from '../../../../ui-data-hooks';
 import { pluginLogger } from '../../../../utils';
 import { IntlMessages, UseLocaleMessagesProps } from './types';
+import { fetchLocaleAndStore, mergeLocaleMessages } from './utils';
 
 function useLocaleMessagesAuxiliary(
   { pluginApi, fetchConfigs }: UseLocaleMessagesProps,
@@ -11,20 +12,35 @@ function useLocaleMessagesAuxiliary(
     fallbackLocale: 'en',
   });
 
-  const [loading, setLoading] = React.useState(true);
-  const [messages, setMessages] = React.useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(true);
+  const [messages, setMessages] = useState<Record<string, string>>({});
+  const [fallbackMessages, setFallbackMessages] = useState<Record<string, string>>();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (pluginApi?.localesBaseUrl && currentLocale.locale) {
       const { localesBaseUrl } = pluginApi;
-      const { locale } = currentLocale;
+      const { locale, fallbackLocale } = currentLocale;
       const localeUrl = `${localesBaseUrl}/${locale}.json`;
-      fetch(localeUrl, fetchConfigs).then((result) => result.json()).then((localeMessages) => {
+      const fallbackLocaleUrl = `${localesBaseUrl}/${fallbackLocale}.json`;
+      Promise.all([
+        localeUrl,
+        fallbackLocaleUrl,
+      ].map((url) => {
+        if (url !== fallbackLocaleUrl || !fallbackMessages) {
+          try {
+            return fetchLocaleAndStore(url, fetchConfigs);
+          } catch (err) {
+            pluginLogger.error(`Something went wrong while trying to fetch ${localeUrl}: `, err);
+            return Promise.reject(err);
+          }
+        }
+        return Promise.resolve(fallbackMessages);
+      })).then((values) => {
+        const [desiredLocale, fallbackLocaleMessages] = values;
+        setMessages(mergeLocaleMessages(desiredLocale, fallbackLocaleMessages));
+        if (!fallbackMessages) setFallbackMessages(fallbackLocaleMessages);
+      }).finally(() => {
         setLoading(false);
-        setMessages(localeMessages);
-      }).catch((err) => {
-        setLoading(false);
-        pluginLogger.error(`Something went wrong while trying to fetch ${localeUrl}: `, err);
       });
     }
   }, [currentLocale]);

--- a/src/core/auxiliary/plugin-information/locale-messages/utils.ts
+++ b/src/core/auxiliary/plugin-information/locale-messages/utils.ts
@@ -1,0 +1,17 @@
+async function fetchLocaleAndStore(
+  localeUrl: string,
+  fetchConfigs?: RequestInit,
+): Promise<Record<string, string>> {
+  const result = await fetch(localeUrl, fetchConfigs);
+  const localeMessages = await result.json();
+  return localeMessages;
+}
+
+function mergeLocaleMessages(
+  desiredMessages: Record<string, string>,
+  fallbackMessages: Record<string, string>,
+): Record<string, string> {
+  return { ...fallbackMessages, ...desiredMessages };
+}
+
+export { fetchLocaleAndStore, mergeLocaleMessages };


### PR DESCRIPTION
### What does this PR do?

it fixes the locale fallback for our useLocaleMessages hook

### Motivation

Previously, if the localeUrl was not accessible, the hook would send the previous locale selected as default (so if I am changing from pt-BR -> fr, the locales would still be pt-BR instead of en which is usually the fallback)

### More

No PRs from CORE is needed.

See demo below:

1. Locale is en;
2. Change locale to pt-BR (which is already complete for `pick-random-user`);
3. Change locale to fr (which is mocked to not be complete);
4. See that the labels that does exist are there in French, and the ones that doesn't, are in English (current behaviour of BBB-core); 

https://github.com/user-attachments/assets/5568291f-9437-41ad-aa80-2ab0f3e3a80a

