### PR TITLE
fix: fix useLocaleMessages and refactor useUiData

### DIFF
--- a/src/core/auxiliary/plugin-information/locale-messages/useLocaleMessages.ts
+++ b/src/core/auxiliary/plugin-information/locale-messages/useLocaleMessages.ts
@@ -22,16 +22,22 @@ function useLocaleMessagesAuxiliary(
       const { locale, fallbackLocale } = currentLocale;
       const localeUrl = `${localesBaseUrl}/${locale}.json`;
       const fallbackLocaleUrl = `${localesBaseUrl}/${fallbackLocale}.json`;
-      Promise.all([
-        localeUrl,
+      pluginLogger.info(`Fetching locale [${locale}] and fallback [${fallbackLocale}] for plugin [${pluginApi.pluginName}]`);
+      const urlToFetchList = [
         fallbackLocaleUrl,
-      ].map((url) => {
+      ];
+      if (locale !== fallbackLocale) urlToFetchList.push(localeUrl);
+      Promise.all(urlToFetchList.map(async (url) => {
         if (url !== fallbackLocaleUrl || !fallbackMessages) {
           try {
-            return fetchLocaleAndStore(url, fetchConfigs);
+            const a = await fetchLocaleAndStore(url, fetchConfigs);
+            return a;
           } catch (err) {
-            pluginLogger.error(`Something went wrong while trying to fetch ${localeUrl}: `, err);
-            return Promise.reject(err);
+            pluginLogger.error(
+              `[${pluginApi.pluginName}] - Something went wrong while trying to fetch [${url}] or parse its result: `,
+              err,
+            );
+            return Promise.resolve({});
           }
         }
         return Promise.resolve(fallbackMessages);

--- a/src/core/utils/hooks.ts
+++ b/src/core/utils/hooks.ts
@@ -1,0 +1,9 @@
+import { useEffect, useRef } from 'react';
+
+export const usePreviousValue = <T = unknown>(value: T) => {
+  const ref = useRef<T>();
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+};

--- a/src/ui-data/hooks/hooks.ts
+++ b/src/ui-data/hooks/hooks.ts
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react';
+import { sortedStringify } from '../../data-consumption/utils';
+import { usePreviousValue } from '../../core/utils/hooks';
 import { UiDataPayloads } from '../types';
 import { UI_DATA_LISTENER_SUBSCRIBED } from './consts';
 
@@ -6,9 +8,18 @@ export function useUiData<
   T extends keyof UiDataPayloads
 >(dataName: T, defaultValue: UiDataPayloads[T]): UiDataPayloads[T] {
   const [data, setData] = useState<UiDataPayloads[T]>(defaultValue);
+  const prevData = usePreviousValue(data);
+
+  // Use this state to avoid unnecessary updates into the data content
+  const [deduplicatedData, setDeduplicatedData] = useState(defaultValue);
+
   const dataStoringFunction = ((customEvent: CustomEvent<UiDataPayloads[T]>) => {
     setData(customEvent.detail);
   }) as EventListener;
+
+  useEffect(() => {
+    if (sortedStringify(data) !== sortedStringify(prevData)) setDeduplicatedData(data);
+  }, [data]);
 
   useEffect(() => {
     window.addEventListener(dataName, dataStoringFunction);
@@ -18,5 +29,5 @@ export function useUiData<
     };
   }, []);
 
-  return data;
+  return deduplicatedData;
 }


### PR DESCRIPTION
### What does this PR do?

It does 2 things:

- Fix the wrong behaviour in `useLocaleMessages` of not returning anything when the fallback locale fails to be fetched or parsed;
- Refactor `useUiData` to not update its state when the content doesn't change - This lead to unnecessary fetches in the `useLocaleMessages` hook;

### Closes Issue(s)

Closes #184


### Motivation

Desired language was not being fetched when fallback locale file had a problem (even if the desired locale file was working properly). 

### More

Nothing to be changed in the CORE.
