### PR TITLE
docs: add settingsSchema and remove eventPersistence.rateLimiting from manifest.json in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,11 +132,6 @@ Here is as complete `manifest.json` example with all possible configurations:
   ], // One can enable more data-channels to better organize client communication
   "eventPersistence": {
     "isEnabled": true, // By default it is not enabled
-    "maximumPayloadSizeInBytes": 1024,
-    "rateLimiting": {
-      "messagesAllowedPerSecond": 10,
-      "messagesAllowedPerMinute": 20
-    }
   },
   "remoteDataSources": [
     {
@@ -451,7 +446,7 @@ This feature is mainly used for security purposes, see [external data section](#
 
 ### Event persistence
 
-This feature will allow the developer to save an information (which is basically an event) in the `event.xml` file of the meeting if it's being recorded.
+This feature will allow the developer to save an information (an event) in the `event.xml` file of the meeting, if it's being recorded.
 
 To use it, one first need to add the following lines to their `manifest.json`:
 
@@ -460,11 +455,6 @@ To use it, one first need to add the following lines to their `manifest.json`:
   // ...rest of manifest configuration
   "eventPersistence": {
       "isEnabled": true,
-      "maximumPayloadSizeInBytes": 1024,
-      "rateLimiting": {
-          "messagesAllowedPerSecond": 10,
-          "messagesAllowedPerMinute": 20
-      }
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -140,11 +140,51 @@ Here is as complete `manifest.json` example with all possible configurations:
       "fetchMode": "onMeetingCreate", // Possible values: "onMeetingCreate", "onDemand" 
       "permissions": ["moderator", "viewer"]
     }
+  ],
+  "settingsSchema": [
+    {
+      "name": "myJson",
+      "label": "myJson",
+      "required": true,
+      "defaultValue": {
+        "abc": 123
+      },
+      "type": "json" // Possible values: "int", "float", "string", "boolean", "json"
+    }
   ]
 }
 ```
 
 To better understand remote-data-sources, please, refer to [this section](#external-data-resources)
+
+**settingsSchema:**
+
+The settingsSchema serves two main purposes:
+
+1. **Validation:** Ensures that all required settings are provided for a plugin. If any required setting is missing, the plugin will not load.
+2. **Configuration Exposure:** Lists all available settings for the plugin, enabling external systems—such as a Learning Management System (LMS)—to present these settings to a meeting organizer. This allows the organizer to configure the plugin manually before the meeting begins.
+
+| **Name**       | **Required** | **Description**                                                                                                |
+| -------------- | ------------ | -------------------------------------------------------------------------------------------------------------- |
+| `name`         | Yes          | The name of the setting as defined in the YAML file                                                            |
+| `label`        | No           | A user-facing label that appears in the integration UI                                                         |
+| `required`     | Yes          | Indicates whether this setting must be provided (`true` or `false`)                                            |
+| `defaultValue` | No           | The default value to use if no setting is explicitly defined                                                   |
+| `type`         | Yes          | The expected data type for the setting. Possible values: `"int"`, `"float"`, `"string"`, `"boolean"`, `"json"` |
+
+**Example**
+
+Given the `settingsSchema` defined in the `manifest.json` seen, the corresponding YAML configuration file (`/etc/bigbluebutton/bbb-html5.yml`) would look like:
+
+```yml
+public:
+  plugins:
+    - name: MyPlugin
+      settings:
+        myJson:
+          abc: my123
+          def: 3234
+```
 
 ## Testing SDK
 

--- a/samples/sample-use-meeting/manifest.json
+++ b/samples/sample-use-meeting/manifest.json
@@ -4,11 +4,6 @@
   "javascriptEntrypointUrl": "SampleUseMeeting.js",
   "localesBaseUrl": "https://cdn.dominio.com/pluginabc/",
   "eventPersistence": {
-      "isEnabled": true,
-      "maximumPayloadSizeInBytes": 1024,
-      "rateLimiting": {
-          "messagesAllowedPerSecond": 10,
-          "messagesAllowedPerMinute": 20
-      }
+      "isEnabled": true
   }
 }


### PR DESCRIPTION
### What does this PR do?

Currently we do not support the eventPersistence.rateLimiting nor eventPersistence.maximumPayloadSize, so the idea is to remove those to not confuse developers.

One other item is to add the latest settingsSchema to the readme of the SDK as it's done in the official docs.
