### PR TITLE
feat(ui-commands): allow toggling the display of audio captions

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,8 @@ One other thing is that the type of the return is precisely the same type requir
   - send: This function will send a notification for the client to render, keep in mind that it's only client-side. Should you want it to be rendered in multiple clients, use this with a data-channel;
 - user-status:
   - setAwayStatus: this function will set the away status of the user to a certain status;
+- captions:
+  - setDisplayAudioCaptions: This function will set the track of transcripted audio to be displayed;
 
 See usage ahead:
 

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ One other thing is that the type of the return is precisely the same type requir
 - user-status:
   - setAwayStatus: this function will set the away status of the user to a certain status;
 - captions:
-  - setDisplayAudioCaptions: This function will set the track of transcripted audio to be displayed;
+  - setDisplayAudioCaptions: This function will set the track of transcripted audio to be displayed or disable it;
 
 See usage ahead:
 

--- a/src/ui-commands/captions/commands.ts
+++ b/src/ui-commands/captions/commands.ts
@@ -1,0 +1,31 @@
+import { CaptionsEnum } from './enums';
+import { SetDisplayAudioCaptionsCommandArguments } from './types';
+
+export const captions = {
+  /**
+   * Sets the automatically generated audio captions to be displayed/or not in the client.
+   *
+   * @param setDisplayAudioCaptionsCommandArguments: object with a
+   * {@link CaptionsLanguageEnum} that tells the language to which the core will set the
+   * display of the audio captions. If the value is `CaptionsLanguageEnum.NONE`, it will hide the
+   * audio captions.
+   * Refer to {@link SetDisplayAudioCaptionsCommandArguments} to understand the argument structure.
+   */
+  setDisplayAudioCaptions: (
+    setDisplayAudioCaptions: SetDisplayAudioCaptionsCommandArguments,
+  ) => {
+    const {
+      displayAudioCaptions,
+    } = setDisplayAudioCaptions;
+    window.dispatchEvent(
+      new CustomEvent<
+        SetDisplayAudioCaptionsCommandArguments
+      >(CaptionsEnum.SET_DISPLAY_AUDIO_CAPTIONS, {
+        detail: {
+          displayAudioCaptions,
+        },
+      }),
+    );
+  },
+
+};

--- a/src/ui-commands/captions/enums.ts
+++ b/src/ui-commands/captions/enums.ts
@@ -1,0 +1,13 @@
+export enum CaptionsEnum {
+  SET_DISPLAY_AUDIO_CAPTIONS = 'SET_SHOW_AUDIO_CAPTIONS_COMMAND',
+}
+
+export enum CaptionsLanguageEnum {
+  NONE = '',
+  ENGLISH = 'en-US',
+  SPANISH = 'es-ES',
+  PORTUGUESE = 'pt-PT',
+  PORTUGUESE_BR = 'pt-BR',
+  FRENCH = 'fr-FR',
+  GERMAN = 'de-DE',
+}

--- a/src/ui-commands/captions/types.ts
+++ b/src/ui-commands/captions/types.ts
@@ -1,0 +1,11 @@
+import { CaptionsLanguageEnum } from './enums';
+
+export interface SetDisplayAudioCaptionsCommandArguments {
+  displayAudioCaptions: CaptionsLanguageEnum;
+}
+
+export interface UiCommandsCaptionsObject {
+  setDisplayAudioCaptions: (
+    setDisplayAudioCaptionsCommandArguments: SetDisplayAudioCaptionsCommandArguments
+  ) => void;
+}

--- a/src/ui-commands/commands.ts
+++ b/src/ui-commands/commands.ts
@@ -6,6 +6,7 @@ import { userStatus } from './user-status/commands';
 import { conference } from './conference/commands';
 import { notification } from './notification/commands';
 import { camera } from './camera/commands';
+import { captions } from './captions/commands';
 import { actionsBar } from './actions-bar/commands';
 import { layout } from './layout/commands';
 import { navBar } from './nav-bar/commands';
@@ -13,6 +14,7 @@ import { navBar } from './nav-bar/commands';
 export const uiCommands = {
   actionsBar,
   camera,
+  captions,
   chat,
   externalVideo,
   sidekickOptionsContainer,

--- a/src/ui-commands/index.ts
+++ b/src/ui-commands/index.ts
@@ -1,2 +1,3 @@
 export { NotificationTypeUiCommand } from './notification/enums';
 export { ChangeEnforcedLayoutTypeEnum } from './layout/enums';
+export { CaptionsLanguageEnum } from './captions/enums';

--- a/src/ui-commands/types.ts
+++ b/src/ui-commands/types.ts
@@ -9,12 +9,14 @@ import { UiCommandsActionsBarObject } from './actions-bar/types';
 import { UiCommandsLayoutObject } from './layout/types';
 import { UiCommandsNavBarObject } from './nav-bar/types';
 import { UiCommandsCameraObject } from './camera/types';
+import { UiCommandsCaptionsObject } from './captions/types';
 
 export interface UiCommands {
   layout: UiCommandsLayoutObject;
   actionsBar: UiCommandsActionsBarObject;
   camera: UiCommandsCameraObject;
   chat: UiCommandsChatObject;
+  captions: UiCommandsCaptionsObject;
   externalVideo: UiCommandsExternalVideoObject;
   sidekickOptionsContainer: UiCommandsSidekickOptionsContainerObject;
   navBar: UiCommandsNavBarObject;


### PR DESCRIPTION
### What does this PR do?
- Adds new UI Command to allow plugins toggling the display of audio captions as well as selecting a specific transcription track to be viewed.
- docs: adds captions ui command to readme

### Closes Issue(s)
Closes #none

Core PR: 
- https://github.com/bigbluebutton/bigbluebutton/pull/23487