### PR TITLE
feat: Added custom-query and custom-mutation for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,59 @@ export interface GraphqlResponseWrapper<TData> {
 
 So we have the `data`, which is different for each hook, that's why it's a generic, the error, that will be set if, and only if, there is an error, otherwise it is undefined, and loading, which tells the developer if the query is still loading (being fetched) or not.
 
+### Realtime Data Creation
+
+**`useCustomMutation` Hook**
+
+The `useCustomMutation` hook enables you to post data to the backend (Postgres) using existing GraphQL mutations, respecting user permissions.
+
+It works similarly to Apollo Client’s `useMutation`, returning a *trigger function* and a *result object* with information about the mutation execution. These will be described in more detail below.
+
+One important difference is that the mutation query **must** be provided as a string. This is due to how the SDK communicates with the HTML5 client. As a consequence, you must explicitly define the type of the `variables` argument for the trigger function, as shown in the example below.
+
+```typescript
+interface MutationVariablesType {
+  reactionEmoji: string;
+}
+
+const [trigger, result] = pluginApi.useCustomMutation<MutationVariablesType>(`
+  mutation SetReactionEmoji($reactionEmoji: String!) {
+    userSetReactionEmoji(reactionEmoji: $reactionEmoji)
+  }
+`);
+
+// Later in the code, you can trigger the mutation:
+trigger({
+  variables: {
+    reactionEmoji: '👏',
+  },
+});
+```
+
+Note that the same type (`MutationVariablesType`) passed as the generic parameter to `useCustomMutation` is also the type of the `variables` object in the trigger function.
+
+The `result` object returned by the hook contains the following fields:
+
+```typescript
+const {
+  called,
+  data,
+  error,
+  loading,
+} = result;
+```
+
+which follow this interface:
+
+```typescript
+interface MutationResultObject {
+  called: boolean;   // Indicates if the trigger function has been called
+  data?: object;     // Response data after the mutation is triggered
+  error?: object;    // Error details from the mutation execution
+  loading: boolean;  // Whether the mutation is currently loading (triggered or in progress)
+}
+```
+
 ### Real time data exchange
 
 - `useDataChannel` hook: this will allow you to exchange information (Send and receive) amongst different users through the same plugin;

--- a/package-lock.json
+++ b/package-lock.json
@@ -422,13 +422,12 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.2.16",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.16.tgz",
-      "integrity": "sha512-LLFWr12ZhBJ4YVw7neWLe6Pk7Ey5R9OCydfuMsz1L8bZxzaawJj2p06Q8/EFEHDeTBQNFLF62X+CG7B2zIyu0Q==",
+      "version": "18.3.23",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
+      "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
-        "@types/scheduler": "*",
         "csstype": "^3.0.2"
       }
     },
@@ -440,12 +439,6 @@
       "dependencies": {
         "@types/react": "*"
       }
-    },
-    "node_modules/@types/scheduler": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
-      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==",
-      "dev": true
     },
     "node_modules/@types/semver": {
       "version": "7.5.0",

--- a/samples/sample-options-dropdown-plugin/src/sample-options-dropdown-plugin-item/component.tsx
+++ b/samples/sample-options-dropdown-plugin/src/sample-options-dropdown-plugin-item/component.tsx
@@ -8,14 +8,26 @@ import {
 import { SampleOptionsDropdownPluginProps } from './types';
 import { UserAggregatorQuery } from './user-aggregator-query/component';
 
+interface MutationVariablesType {
+  reactionEmoji: string,
+}
+
 function SampleOptionsDropdownPlugin(
   { pluginUuid: uuid }: SampleOptionsDropdownPluginProps,
 ): React.ReactElement<SampleOptionsDropdownPluginProps> {
   const pluginApi: PluginApi = BbbPluginSdk.getPluginApi(uuid);
   BbbPluginSdk.initialize(uuid);
   const [activateQuery, setActivateQuery] = React.useState(false);
+  const [trigger] = pluginApi.useCustomMutation<MutationVariablesType>(`
+    mutation SetReactionEmoji($reactionEmoji: String!) {
+      userSetReactionEmoji(
+        reactionEmoji: $reactionEmoji,
+      )
+    }
+  `);
 
   useEffect(() => {
+    pluginApi.setOptionsDropdownItems([]);
     pluginApi.setOptionsDropdownItems([
       new OptionsDropdownSeparator(),
       new OptionsDropdownOption({
@@ -26,8 +38,22 @@ function SampleOptionsDropdownPlugin(
           pluginLogger.info('Log from options dropdown plugin');
         },
       }),
+      new OptionsDropdownOption({
+        label: 'This will set your reaction to 👏',
+        icon: 'copy',
+        onClick: () => {
+          pluginLogger.info('Setting reaction to 👏');
+          if (trigger) {
+            trigger({
+              variables: {
+                reactionEmoji: '👏',
+              },
+            });
+          }
+        },
+      }),
     ]);
-  }, []);
+  }, [trigger]);
 
   return activateQuery && (
     <UserAggregatorQuery

--- a/samples/sample-options-dropdown-plugin/src/sample-options-dropdown-plugin-item/component.tsx
+++ b/samples/sample-options-dropdown-plugin/src/sample-options-dropdown-plugin-item/component.tsx
@@ -6,11 +6,14 @@ import {
   pluginLogger,
 } from 'bigbluebutton-html-plugin-sdk';
 import { SampleOptionsDropdownPluginProps } from './types';
+import { UserAggregatorQuery } from './user-aggregator-query/component';
 
 function SampleOptionsDropdownPlugin(
   { pluginUuid: uuid }: SampleOptionsDropdownPluginProps,
 ): React.ReactElement<SampleOptionsDropdownPluginProps> {
   const pluginApi: PluginApi = BbbPluginSdk.getPluginApi(uuid);
+  BbbPluginSdk.initialize(uuid);
+  const [activateQuery, setActivateQuery] = React.useState(false);
 
   useEffect(() => {
     pluginApi.setOptionsDropdownItems([
@@ -19,13 +22,18 @@ function SampleOptionsDropdownPlugin(
         label: 'This will log on the console',
         icon: 'copy',
         onClick: () => {
+          setActivateQuery(true);
           pluginLogger.info('Log from options dropdown plugin');
         },
       }),
     ]);
   }, []);
 
-  return null;
+  return activateQuery && (
+    <UserAggregatorQuery
+      pluginApi={pluginApi}
+    />
+  );
 }
 
 export default SampleOptionsDropdownPlugin;

--- a/samples/sample-options-dropdown-plugin/src/sample-options-dropdown-plugin-item/user-aggregator-query/component.tsx
+++ b/samples/sample-options-dropdown-plugin/src/sample-options-dropdown-plugin-item/user-aggregator-query/component.tsx
@@ -1,0 +1,37 @@
+import {
+  PluginApi,
+  pluginLogger,
+} from 'bigbluebutton-html-plugin-sdk';
+import { useEffect } from 'react';
+
+interface UserAggregatorQueryProps {
+  pluginApi: PluginApi;
+}
+
+interface QueryResult {
+  user_aggregate: {
+    aggregate: {
+      count: number;
+    }
+  }
+}
+
+function UserAggregatorQuery(
+  props: UserAggregatorQueryProps,
+):React.ReactElement<UserAggregatorQueryProps> {
+  const { pluginApi } = props;
+  const { data, loading } = pluginApi.useCustomQuery<QueryResult>(`
+    query UsersCount {
+    user_aggregate {
+      aggregate {
+        count
+      }
+    }
+  }`);
+  useEffect(() => {
+    pluginLogger.info(`This is the result of the query: ${data}`);
+  }, [loading]);
+  return null;
+}
+
+export { UserAggregatorQuery };

--- a/samples/sample-options-dropdown-plugin/src/sample-options-dropdown-plugin-item/user-aggregator-query/component.tsx
+++ b/samples/sample-options-dropdown-plugin/src/sample-options-dropdown-plugin-item/user-aggregator-query/component.tsx
@@ -18,7 +18,7 @@ interface QueryResult {
 
 function UserAggregatorQuery(
   props: UserAggregatorQueryProps,
-):React.ReactElement<UserAggregatorQueryProps> {
+): React.ReactElement<UserAggregatorQueryProps> {
   const { pluginApi } = props;
   const { data, loading } = pluginApi.useCustomQuery<QueryResult>(`
     query UsersCount {
@@ -29,7 +29,7 @@ function UserAggregatorQuery(
     }
   }`);
   useEffect(() => {
-    pluginLogger.info(`This is the result of the query: ${data}`);
+    pluginLogger.info(`This is the result of the query: ${JSON.stringify(data)}`);
   }, [loading]);
   return null;
 }

--- a/src/core/api/BbbPluginSdk.ts
+++ b/src/core/api/BbbPluginSdk.ts
@@ -53,6 +53,9 @@ import { persistEventFunctionWrapper } from '../../event-persistence/hooks';
 import useLocaleMessagesAuxiliary from '../auxiliary/plugin-information/locale-messages/useLocaleMessages';
 import { getUiData } from '../../ui-data/getters/getters';
 import { useCustomQuery } from '../../data-consumption/domain/shared/custom-query/hooks';
+import { UseCustomQueryFunction } from '../../data-consumption/domain/shared/custom-query/types';
+import { useCustomMutation } from '../../data-creation/hook';
+import { UseCustomMutationFunction } from '../../data-creation/types';
 
 declare const window: PluginBrowserWindow;
 
@@ -85,7 +88,11 @@ export abstract class BbbPluginSdk {
     pluginApi.useCustomQuery = ((
       query: string,
       variablesObjectWrapper?: CustomQueryHookOptions,
-    ) => useCustomQuery(query, variablesObjectWrapper)) as UseCustomSubscriptionFunction;
+    ) => useCustomQuery(query, variablesObjectWrapper)) as UseCustomQueryFunction;
+    pluginApi.useCustomMutation = ((
+      mutation: string,
+      options?: object,
+    ) => useCustomMutation(mutation, options)) as UseCustomMutationFunction;
     pluginApi.useCurrentPresentation = (
       () => useCurrentPresentation()) as UseCurrentPresentationFunction;
     pluginApi.useLoadedUserList = (() => useLoadedUserList()) as UseLoadedUserListFunction;
@@ -127,10 +134,8 @@ export abstract class BbbPluginSdk {
       pluginApi.getRemoteData = (
         dataSourceName: string,
       ) => getRemoteData(dataSourceName, pluginName);
-      pluginApi.persistEvent = <T = object>(
-        eventName: string,
-        payload: T,
-      ) => persistEventFunctionWrapper(
+      pluginApi
+        .persistEvent = <T = object>(eventName: string, payload: T) => persistEventFunctionWrapper(
           pluginName,
           eventName,
           payload,

--- a/src/core/api/BbbPluginSdk.ts
+++ b/src/core/api/BbbPluginSdk.ts
@@ -16,6 +16,7 @@ import {
 } from '../../data-channel/types';
 import { uiCommands } from '../../ui-commands/commands';
 import {
+  CustomQueryHookOptions,
   CustomSubscriptionHookOptions,
 } from '../../index';
 import {
@@ -51,6 +52,7 @@ import { getRemoteData } from '../../remote-data/utils';
 import { persistEventFunctionWrapper } from '../../event-persistence/hooks';
 import useLocaleMessagesAuxiliary from '../auxiliary/plugin-information/locale-messages/useLocaleMessages';
 import { getUiData } from '../../ui-data/getters/getters';
+import { useCustomQuery } from '../../data-consumption/domain/shared/custom-query/hooks';
 
 declare const window: PluginBrowserWindow;
 
@@ -80,6 +82,10 @@ export abstract class BbbPluginSdk {
       query: string,
       variablesObjectWrapper?: CustomSubscriptionHookOptions,
     ) => useCustomSubscription(query, variablesObjectWrapper)) as UseCustomSubscriptionFunction;
+    pluginApi.useCustomQuery = ((
+      query: string,
+      variablesObjectWrapper?: CustomQueryHookOptions,
+    ) => useCustomQuery(query, variablesObjectWrapper)) as UseCustomSubscriptionFunction;
     pluginApi.useCurrentPresentation = (
       () => useCurrentPresentation()) as UseCurrentPresentationFunction;
     pluginApi.useLoadedUserList = (() => useLoadedUserList()) as UseLoadedUserListFunction;
@@ -121,7 +127,7 @@ export abstract class BbbPluginSdk {
       pluginApi.getRemoteData = (
         dataSourceName: string,
       ) => getRemoteData(dataSourceName, pluginName);
-      pluginApi.persistEvent = <T=object>(
+      pluginApi.persistEvent = <T = object>(
         eventName: string,
         payload: T,
       ) => persistEventFunctionWrapper(
@@ -140,8 +146,8 @@ export abstract class BbbPluginSdk {
   private static isReactEnvironment(): boolean {
     const fn = console.error;
     try {
-      console.error = () => {};
-      useEffect(() => {}, []);
+      console.error = () => { };
+      useEffect(() => { }, []);
     } catch {
       console.error = fn;
       console.error('[PLUGIN-ERROR] Error: Initializing pluginApi outside of a react function component. It should be done inside');
@@ -188,7 +194,7 @@ export abstract class BbbPluginSdk {
         setFloatingWindows: () => [],
         setGenericContentItems: () => [],
         mapOfPushEntryFunctions: {
-          '': () => {},
+          '': () => { },
         },
         getSessionToken: () => getSessionToken(),
         pluginName,

--- a/src/core/api/types.ts
+++ b/src/core/api/types.ts
@@ -35,6 +35,7 @@ import { PersistEventFunction } from '../../event-persistence/types';
 import { UseLocaleMessagesFunction } from '../auxiliary/plugin-information/locale-messages/types';
 import { UseShouldUnmountPluginFunction } from '../auxiliary/plugin-unmount/types';
 import { GetUiDataFunction } from '../../ui-data/getters/types';
+import { UseCustomQueryFunction } from '../../data-consumption/domain/shared/custom-query/types';
 
 // Setter Functions for the API
 export type SetPresentationToolbarItems = (presentationToolbarItem:
@@ -189,13 +190,21 @@ export interface PluginApi {
    */
   useShouldUnmountPlugin?: UseShouldUnmountPluginFunction;
   /**
-   * Returns an object containing the data on the current presentation being displayed
-   * in the presentation area, and its current page.
+   * Returns an object containing the data related to the custom subscription made.
+   * This hook is reactive - If the resulting data changes, it updates the hook.
    *
    * @returns `GraphqlResponseWrapper` with the data type specified in the generic type.
    *
    */
   useCustomSubscription?: UseCustomSubscriptionFunction;
+  /**
+   * Returns an object containing the data related to the custom subscription made.
+   * This hook is not reactive - Once the data is returned, it doesn't update anymore.
+   *
+   * @returns `GraphqlResponseWrapper` with the data type specified in the generic type.
+   *
+   */
+  useCustomQuery?: UseCustomQueryFunction;
   // --- DataChannel Hook ---
   /**
    * Returns an array with tha data wrapped in the `GraphqlResponseWrapper` in the first

--- a/src/core/api/types.ts
+++ b/src/core/api/types.ts
@@ -36,6 +36,7 @@ import { UseLocaleMessagesFunction } from '../auxiliary/plugin-information/local
 import { UseShouldUnmountPluginFunction } from '../auxiliary/plugin-unmount/types';
 import { GetUiDataFunction } from '../../ui-data/getters/types';
 import { UseCustomQueryFunction } from '../../data-consumption/domain/shared/custom-query/types';
+import { UseCustomMutationFunction } from '../../data-creation/types';
 
 // Setter Functions for the API
 export type SetPresentationToolbarItems = (presentationToolbarItem:
@@ -155,7 +156,7 @@ export interface PluginApi {
    *
    */
   useUsersBasicInfo?: UseUsersBasicInfoFunction;
-   /**
+  /**
    * Returns an object containing brief data on the messages already loaded in the chat.
    *
    * @returns `GraphqlResponseWrapper` with the LoadedChatMessages.
@@ -205,6 +206,14 @@ export interface PluginApi {
    *
    */
   useCustomQuery?: UseCustomQueryFunction;
+  /**
+   * Gives developer the ability to manipulate data from bbb using custom mutations.
+   * It can only use mutations that already exist in bbb.
+   *
+   * @returns an array with the trigger function and the result of the mutation.
+   *
+   */
+  useCustomMutation?: UseCustomMutationFunction;
   // --- DataChannel Hook ---
   /**
    * Returns an array with tha data wrapped in the `GraphqlResponseWrapper` in the first
@@ -310,6 +319,6 @@ export interface MeetingClientSettings {
 }
 
 export interface PluginBrowserWindow extends Window {
-  bbb_plugins: { [key: string]: PluginApi};
+  bbb_plugins: { [key: string]: PluginApi };
   meetingClientSettings?: MeetingClientSettings;
 }

--- a/src/core/enum.ts
+++ b/src/core/enum.ts
@@ -1,14 +1,17 @@
 import { DataChannelHooks } from '../data-channel/enums';
 import { DomElementManipulationHooks } from '../dom-element-manipulation/enums';
 import { DataConsumptionHooks } from '../data-consumption/enums';
+import { DataCreationHookEnums } from '../data-creation/enums';
 
 export enum HookEvents {
   BBB_CORE_SENT_NEW_DATA = 'BBB_CORE_SENT_NEW_DATA',
+  BBB_CORE_UPDATED_STATE = 'BBB_CORE_UPDATED_STATE',
   BBB_CORE_UPDATED_MEETING_STATUS = 'BBB_CORE_UPDATED_MEETING_STATUS',
   /**
    * PLUGIN_SENT_CHANGES_TO_BBB_CORE is used to:
-   *  - Comunicate that the subscription has changed for the dom-element-manipulation hook;
+   *  - Communicate that the subscription has changed for the dom-element-manipulation hook;
    *  - Send replace/delete event for useDataChannel;
+   *  - Trigger the mutation function already created
    */
   PLUGIN_SENT_CHANGES_TO_BBB_CORE = 'PLUGIN_SENT_CHANGES_TO_BBB_CORE',
   PLUGIN_SUBSCRIBED_TO_BBB_CORE = 'PLUGIN_SUBSCRIBED_TO_BBB_CORE',
@@ -18,4 +21,4 @@ export enum HookEvents {
 export const GENERIC_HOOK_PLUGIN = 'GENERIC_HOOK_PLUGIN';
 
 export type Hooks = DataConsumptionHooks | DataChannelHooks
-| DomElementManipulationHooks | typeof GENERIC_HOOK_PLUGIN;
+  | DomElementManipulationHooks | DataCreationHookEnums | typeof GENERIC_HOOK_PLUGIN;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -3,6 +3,7 @@ import { CustomSubscriptionArguments } from '../data-consumption/domain/shared/c
 import { Hooks } from './enum';
 import { DataChannelArguments } from '../data-channel/types';
 import { DomElementManipulationArguments } from '../dom-element-manipulation/type';
+import { UseCustomMutationArguments } from '../data-creation/types';
 
 /**
  * Wrapper for the data that comes from the core. With this more complex object
@@ -18,7 +19,7 @@ export interface GraphqlResponseWrapper<TData> {
 }
 
 export type HookArguments = CustomSubscriptionArguments | DataChannelArguments
-  | DomElementManipulationArguments;
+  | DomElementManipulationArguments | UseCustomMutationArguments;
 
 export interface UpdatedEventDetails<T> {
   hook: Hooks;

--- a/src/data-consumption/domain/shared/custom-query/hooks.ts
+++ b/src/data-consumption/domain/shared/custom-query/hooks.ts
@@ -1,0 +1,11 @@
+import { DataConsumptionHooks } from '../../../../data-consumption/enums';
+import { createDataConsumptionHook } from '../../../factory/hookCreator';
+import { CustomQueryArguments, CustomQueryHookOptions, UseCustomQueryFunction } from './types';
+
+export const useCustomQuery: UseCustomQueryFunction = <T>(
+  query: string,
+  options?: CustomQueryHookOptions,
+) => createDataConsumptionHook<T>(DataConsumptionHooks.CUSTOM_QUERY, {
+  query,
+  variables: options?.variables,
+} as CustomQueryArguments);

--- a/src/data-consumption/domain/shared/custom-query/types.ts
+++ b/src/data-consumption/domain/shared/custom-query/types.ts
@@ -1,0 +1,15 @@
+import { GraphqlResponseWrapper } from '../../../../core';
+
+export interface CustomQueryArguments {
+  query?: string;
+  variables?: object;
+}
+
+export interface CustomQueryHookOptions {
+  variables: object;
+}
+
+export type UseCustomQueryFunction = <T>(
+  query: string,
+  variablesObjectWrapper?: CustomQueryHookOptions,
+) => GraphqlResponseWrapper<T>;

--- a/src/data-consumption/domain/shared/index.ts
+++ b/src/data-consumption/domain/shared/index.ts
@@ -1,1 +1,2 @@
 export { CustomSubscriptionHookOptions } from './custom-subscription/types';
+export { CustomQueryHookOptions } from './custom-query/types';

--- a/src/data-consumption/domain/shared/types.ts
+++ b/src/data-consumption/domain/shared/types.ts
@@ -1,0 +1,4 @@
+import { CustomQueryArguments } from './custom-query/types';
+import { CustomSubscriptionArguments } from './custom-subscription/types';
+
+export type DataConsumptionArguments = CustomSubscriptionArguments | CustomQueryArguments;

--- a/src/data-consumption/enums.ts
+++ b/src/data-consumption/enums.ts
@@ -6,4 +6,5 @@ export enum DataConsumptionHooks {
   MEETING = 'Hooks::UseMeeting',
   TALKING_INDICATOR = 'Hooks::UseTalkingIndicator',
   CUSTOM_SUBSCRIPTION = 'Hooks::CustomSubscription',
+  CUSTOM_QUERY = 'Hooks::CustomQuery',
 }

--- a/src/data-creation/enums.ts
+++ b/src/data-creation/enums.ts
@@ -1,0 +1,6 @@
+export enum DataCreationHookEnums {
+  CREATE_NEW_CUSTOM_MUTATION = 'Hooks::CreateNewCustomMutation',
+  TRIGGER_MUTATION = 'Hooks::TriggerMutation',
+  MUTATION_READY = 'Hooks::MutationReady',
+  MUTATION_RESULT_SENT = 'Hooks::MutationResultSent',
+}

--- a/src/data-creation/hook.ts
+++ b/src/data-creation/hook.ts
@@ -1,0 +1,126 @@
+import { useEffect, useState } from 'react';
+import {
+  MutationResultObject,
+  MutationHookResultType,
+  MutationVariablesWrapper,
+  UseCustomMutationReturnType,
+} from './types';
+import { HookEvents } from '../core/enum';
+import {
+  GraphqlResponseWrapper,
+  HookEventWrapper,
+  SubscribedEventDetails,
+  UpdatedEventDetails,
+} from '../core/types';
+import { DataCreationHookEnums } from './enums';
+import validateMutationEventFromClient from './utils';
+
+export function useCustomMutation<T>(
+  mutation: string,
+  options?: object,
+): UseCustomMutationReturnType<T> {
+  const [mutationHookResult, setMutationHookResult] = useState<MutationHookResultType<T>>(
+    {
+      triggerFunction: null,
+      result: {
+        loading: true,
+        called: false,
+      },
+    },
+  );
+
+  const triggerFunction = ((data: MutationVariablesWrapper<T>) => {
+    window.dispatchEvent(
+      new CustomEvent<UpdatedEventDetails<
+        MutationVariablesWrapper<T>
+      >>(HookEvents.PLUGIN_SENT_CHANGES_TO_BBB_CORE, {
+        detail: {
+          hook: DataCreationHookEnums.TRIGGER_MUTATION,
+          hookArguments: {
+            mutation,
+            options,
+          },
+          data,
+        },
+      }),
+    );
+  });
+
+  // This function is responsible for setting the trigger function of the mutation
+  const handleMutationReadyEvent: EventListener = (
+    (event: HookEventWrapper<GraphqlResponseWrapper<void>>) => {
+      validateMutationEventFromClient(
+        setMutationHookResult,
+        (prevMutationResultObject) => ({
+          triggerFunction,
+          result: prevMutationResultObject.result,
+        }),
+        DataCreationHookEnums.MUTATION_READY,
+        event,
+        mutation,
+        options,
+      );
+    }) as EventListener;
+
+  // This function is responsible for setting the result of the mutation;
+  const handleMutationResultSentEvent: EventListener = (
+    (event: HookEventWrapper<GraphqlResponseWrapper<void>>) => {
+      validateMutationEventFromClient<T, MutationResultObject>(
+        setMutationHookResult,
+        (prevMutationResultObject, dataFromEvent) => ({
+          triggerFunction: prevMutationResultObject.triggerFunction,
+          result: dataFromEvent,
+        }),
+        DataCreationHookEnums.MUTATION_RESULT_SENT,
+        event,
+        mutation,
+        options,
+      );
+    }) as EventListener;
+
+  useEffect(() => {
+    window.dispatchEvent(
+      new CustomEvent<SubscribedEventDetails>(HookEvents.PLUGIN_SUBSCRIBED_TO_BBB_CORE, {
+        detail: {
+          hook: DataCreationHookEnums.CREATE_NEW_CUSTOM_MUTATION,
+          hookArguments: {
+            mutation,
+            options,
+          },
+        },
+      }),
+    );
+    window.addEventListener(
+      HookEvents.BBB_CORE_UPDATED_STATE,
+      handleMutationReadyEvent,
+    );
+    window.addEventListener(
+      HookEvents.BBB_CORE_UPDATED_STATE,
+      handleMutationResultSentEvent,
+    );
+
+    return () => {
+      window.dispatchEvent(
+        new CustomEvent<SubscribedEventDetails>(HookEvents.PLUGIN_UNSUBSCRIBED_FROM_BBB_CORE, {
+          detail: {
+            hook: DataCreationHookEnums.CREATE_NEW_CUSTOM_MUTATION,
+            hookArguments: {
+              mutation,
+              options,
+            },
+          },
+        }),
+      );
+      window.removeEventListener(
+        HookEvents.BBB_CORE_UPDATED_STATE,
+        handleMutationReadyEvent,
+      );
+      window.removeEventListener(
+        HookEvents.BBB_CORE_UPDATED_STATE,
+        handleMutationResultSentEvent,
+      );
+    };
+  }, []);
+
+  return [mutationHookResult.triggerFunction, mutationHookResult.result];
+}

--- a/src/data-creation/types.ts
+++ b/src/data-creation/types.ts
@@ -1,0 +1,33 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export interface MutationVariablesWrapper<T> {
+  variables: T;
+}
+export type TriggerMutationFunction<T> = (args: MutationVariablesWrapper<T>) => void;
+
+export type UseCustomMutationReturnType<T> = [TriggerMutationFunction<T> | null, object | null]
+
+export type UseCustomMutationFunction = <T = any>(
+  mutation: string, options?: object
+) => UseCustomMutationReturnType<T>;
+
+export interface UseCustomMutationArguments {
+  mutation: string;
+  options?: object;
+}
+
+export interface MutationResultObject {
+  called: boolean;
+  data?: object;
+  error?: object;
+  loading: boolean
+}
+
+export interface MutationHookResultType<T> {
+  triggerFunction: TriggerMutationFunction<T> | null;
+  result: MutationResultObject | null;
+}
+
+export type SetterFunctionCallbackType<T, K> = (
+  previousObject: MutationHookResultType<T>,
+  dataFromEvent: K
+) => MutationHookResultType<T>;

--- a/src/data-creation/utils.ts
+++ b/src/data-creation/utils.ts
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { makeCustomHookIdentifier } from '../data-consumption/utils';
+import { GraphqlResponseWrapper, HookEventWrapper, UpdatedEventDetails } from '../core/types';
+import { DataCreationHookEnums } from './enums';
+import { MutationHookResultType, SetterFunctionCallbackType, UseCustomMutationArguments } from './types';
+
+const validateMutationEventFromClient = <T, K>(
+  setMutationResult: React.Dispatch<React.SetStateAction<MutationHookResultType<T>>>,
+  setterFunctionCallback: SetterFunctionCallbackType<T, K>,
+  hook: DataCreationHookEnums,
+  event: HookEventWrapper<GraphqlResponseWrapper<object>>,
+  mutation: string,
+  options?: object,
+) => {
+  const {
+    hook: hookReceived,
+    hookArguments,
+    data,
+  } = event.detail as UpdatedEventDetails<K>;
+  const {
+    mutation: mutationReceived,
+    options: optionsReceived,
+  } = (hookArguments || { mutation: null, options: null }) as UseCustomMutationArguments;
+  if (
+    hookReceived === hook
+    && (makeCustomHookIdentifier(mutationReceived, optionsReceived)
+      === makeCustomHookIdentifier(mutation, options))
+  ) {
+    setMutationResult((prevObject) => setterFunctionCallback(prevObject, data));
+  }
+};
+
+export default validateMutationEventFromClient;


### PR DESCRIPTION
### What does this PR do?

This PR adds 2 new features:
- Custom query - Just like the custom subscription, this will fetch data from the back-end, but this is not reactive (it will not update on data change) - This can be useful for things that don't change (or don't change often) during the meeting, such as fetching client settings;
- Custom mutations - Just like the server-commands that are used to change data in the back-end, this will allow user to change basically any data that the user has permission to, that being: change the state of microphone, set reactions (this is explored in one of the plugin samples),  raise hand, stop external-video share; 

### Closes

closes #190

### How to test

One can use the `sample-option-dropdown-plugin` to test this new feature. In there, you'll find both features: custom query and custom mutation. 

### More

Closely related to the PR in the CORE: https://github.com/bigbluebutton/bigbluebutton/pull/23489
