### PR TITLE
fix(tests): Add static timeout for next slide to load in custom subscription hook

### DIFF
--- a/samples/sample-custom-subscription-hook/tests/test.spec.ts
+++ b/samples/sample-custom-subscription-hook/tests/test.spec.ts
@@ -66,6 +66,7 @@ test.describe.parallel('Custom Subscription Hook', () => {
     expect(options.length, 'presentation should have more than 1 slide for the plugin to perform as expected').toBeGreaterThan(1);
     await skipSlideSelect.selectOption({ index: options.length - 1 });
     await expect(sampleTest.modPage.page.locator(e.nextSlide), 'should disable the next slide button when on the last slide').toBeDisabled();
+    await sampleTest.modPage.page.waitForTimeout(1000); // wait for next slide to be loaded
 
     const [consoleMessage2] = await Promise.all([
       sampleTest.modPage.waitForPluginLogger(),


### PR DESCRIPTION
### What does this PR do?
Spotted a possible failure in a CI run where the slide is not fully loaded, and no log is displayed on the custom subscription hook button:

```sh
1) [chromium] › samples/sample-custom-subscription-hook/tests/test.spec.ts:35:3 › Custom Subscription Hook › should display the button with icon and log when clicked 

    Error: should be a valid JavaScript object

    expect(received).toBeTruthy()

    Received: null

      74 |
      75 |     const extractedObject2 = extractObject<NextSlideData>(consoleMessage2.text());
    > 76 |     expect(extractedObject2, 'should be a valid JavaScript object').toBeTruthy();
         |                                                                     ^
      77 |     const pages2 = extractedObject2?.pres_presentation?.[0]?.pages;
      78 |     expect(pages2, 'should not log any data of next slide when on the last slide').toEqual([]);
      79 |   });
        at /home/runner/work/bigbluebutton/bigbluebutton/bigbluebutton-tests/bigbluebutton-html-plugin-sdk/samples/sample-custom-subscription-hook/tests/test.spec.ts:76:69
```

This PR adds a static timeout we usually use on BBB core tests to ensure it's loaded