### PR TITLE
fix: Fix useLocaleMessage hook so it gets a similar locale to the one requested

### DIFF
--- a/src/core/auxiliary/plugin-information/locale-messages/types.ts
+++ b/src/core/auxiliary/plugin-information/locale-messages/types.ts
@@ -1,27 +1,26 @@
 import { PluginApi } from 'src/core/api/types';
 
-interface UseLocaleMessagesProps {
+export interface UseLocaleMessagesProps {
   pluginApi: PluginApi;
   fetchConfigs?: RequestInit;
 }
 
-interface PluginInformationResult {
+export interface PluginInformationResult {
   javascriptEntrypointIntegrity: string;
   javascriptEntrypointUrl: string;
   localesBaseUrl: string;
 }
 
-interface IntlMessages {
+export interface IntlMessages {
   loading: boolean;
   messages: Record<string, string>;
   currentLocale: string;
 }
 
-type UseLocaleMessagesFunction = (fetchConfigs?: RequestInit) => IntlMessages;
+export type UseLocaleMessagesFunction = (fetchConfigs?: RequestInit) => IntlMessages;
 
-export {
-  UseLocaleMessagesProps,
-  PluginInformationResult,
-  IntlMessages,
-  UseLocaleMessagesFunction,
-};
+export interface DataWaitingWrapper<T> {
+  data: T;
+  loading: boolean;
+  error?: object;
+}

--- a/src/core/auxiliary/plugin-information/locale-messages/utils.ts
+++ b/src/core/auxiliary/plugin-information/locale-messages/utils.ts
@@ -1,3 +1,8 @@
+import { useEffect, useState } from 'react';
+import { DataWaitingWrapper, UseLocaleMessagesProps } from './types';
+import { IntlLocaleUiDataNames } from '../../../../ui-data';
+import { LocaleObject } from '../../../../ui-data/domain/intl/locale/types';
+
 async function fetchLocaleAndStore(
   localeUrl: string,
   fetchConfigs?: RequestInit,
@@ -14,4 +19,104 @@ function mergeLocaleMessages(
   return { ...fallbackMessages, ...desiredMessages };
 }
 
-export { fetchLocaleAndStore, mergeLocaleMessages };
+function useGetLocalesIndex(
+  localeUrl: string | undefined,
+  fetchConfigs?: RequestInit,
+): DataWaitingWrapper<string[]> {
+  const [indexOfLocales, setIndexOfLocales] = useState<DataWaitingWrapper<string[]>>({
+    data: [],
+    loading: true,
+  });
+
+  useEffect(() => {
+    if (localeUrl || localeUrl !== '') {
+      const indexUrl = `${localeUrl}/index.json`;
+      fetch(indexUrl, fetchConfigs)
+        .then((res) => res.json())
+        .then((list: string[]) => {
+          const filtered = list.filter((filename) => filename !== 'index.json');
+          setIndexOfLocales({
+            data: filtered,
+            loading: false,
+          });
+        })
+        .catch((error) => {
+          setIndexOfLocales({
+            data: [],
+            loading: false,
+            error,
+          });
+        });
+    }
+  }, [localeUrl]);
+
+  return indexOfLocales;
+}
+
+function useGetNormalizedLocale(
+  { pluginApi, fetchConfigs }: UseLocaleMessagesProps,
+): DataWaitingWrapper<LocaleObject> {
+  const localeFromUiData = pluginApi.useUiData!(IntlLocaleUiDataNames.CURRENT_LOCALE, {
+    locale: 'en',
+    fallbackLocale: 'en',
+  });
+
+  const [
+    currentLocale,
+    setCurrentLocale,
+  ] = useState<DataWaitingWrapper<LocaleObject>>({
+    data: localeFromUiData,
+    loading: true,
+  });
+
+  const localesIndex = useGetLocalesIndex(
+    pluginApi.localesBaseUrl,
+    fetchConfigs,
+  );
+
+  useEffect(() => {
+    if (!localesIndex.loading && !localesIndex.error) {
+      const desiredLocale = localeFromUiData.locale.split(/[-_]/g);
+
+      const usableLocales = localesIndex.data
+        .map((file) => file.replace('.json', ''))
+        .reduce((locales: string[], locale: string) => (locale.match(desiredLocale[0])
+          ? [...locales, locale]
+          : locales), []);
+
+      const isDesiredLocalePresent = usableLocales.findIndex(
+        (locale) => locale === localeFromUiData.locale,
+      ) !== -1;
+
+      if (isDesiredLocalePresent && localeFromUiData.locale !== currentLocale.data.locale) {
+        setCurrentLocale({
+          data: localeFromUiData,
+          loading: false,
+        });
+      } else if (!isDesiredLocalePresent) {
+        const regionDefault = usableLocales.find((locale) => locale === desiredLocale[0]);
+        const localeFallback = regionDefault || usableLocales[0];
+        setCurrentLocale({
+          data: {
+            ...localeFromUiData,
+            locale: localeFallback,
+          },
+          loading: false,
+        });
+      }
+    } else if (localeFromUiData.locale !== currentLocale.data.locale) {
+      setCurrentLocale({
+        data: localeFromUiData,
+        loading: false,
+      });
+    }
+  }, [localeFromUiData, localesIndex]);
+  return currentLocale;
+}
+
+export {
+  fetchLocaleAndStore,
+  mergeLocaleMessages,
+  useGetLocalesIndex,
+  useGetNormalizedLocale,
+};

--- a/src/core/auxiliary/plugin-information/locale-messages/utils.ts
+++ b/src/core/auxiliary/plugin-information/locale-messages/utils.ts
@@ -104,7 +104,10 @@ function useGetNormalizedLocale(
           loading: false,
         });
       }
-    } else if (localeFromUiData.locale !== currentLocale.data.locale) {
+    } else if (
+      !localesIndex.loading
+      && localeFromUiData.locale !== currentLocale.data.locale
+    ) {
       setCurrentLocale({
         data: localeFromUiData,
         loading: false,

--- a/src/ui-data/domain/intl/locale/types.ts
+++ b/src/ui-data/domain/intl/locale/types.ts
@@ -1,8 +1,10 @@
 import { IntlLocaleUiDataNames } from './enums';
 
+export interface LocaleObject {
+  locale: string;
+  fallbackLocale: string;
+}
+
 export type IntlLocaleUiDataPayloads = {
-  [IntlLocaleUiDataNames.CURRENT_LOCALE]: {
-    locale: string;
-    fallbackLocale: string;
-  }
+  [IntlLocaleUiDataNames.CURRENT_LOCALE]: LocaleObject
 };


### PR DESCRIPTION
### What does this PR do?

This PR improves the useLocaleMessages hook by allowing it to load a similar language locale when an exact match isn't available, instead of defaulting to English or, in some cases, falling back to the raw locale key.

### Closes Issue(s)

Closes https://github.com/bigbluebutton/plugin-pick-random-user/issues/48 

### Motivation

Issue https://github.com/bigbluebutton/plugin-pick-random-user/issues/48 highlighted a problem where, if a specific translation wasn't available for a given locale, the hook would fall back to English — even when a similar translation existed (e.g., same language but a different region code). For example, we had fr-FR.json available, but the system expected fr.json. The fallback mechanism failed to handle this gracefully, resulting in untranslated keys or English text. This PR addresses that by resolving to a locale with the same language code when an exact match is missing.

This also prevents similar issues with other languages like Italian and Portuguese that may have region-specific locale files.

### More

**Edit(Important):** For this to work a new file on the plugin side must be created adding all available json translation files for it inside the translations directory, for pick-random-user that would be (directory: `public/locales/index.json`):

```json
[
  "de.json",
  "en.json",
  "fr-FR.json",
  "index.json",
  "it.json",
  "ja.json",
  "pt-BR.json"
]
```
   

See demo of the locales working:

https://github.com/user-attachments/assets/5dde571a-8ac8-4ac8-bcd7-31941d412f3a


