### PR TITLE
fix: imports plugin api using relative path

### DIFF
--- a/src/core/auxiliary/plugin-information/locale-messages/types.ts
+++ b/src/core/auxiliary/plugin-information/locale-messages/types.ts
@@ -1,4 +1,4 @@
-import { PluginApi } from 'src/core/api/types';
+import { PluginApi } from '../../../api/types';
 
 interface UseLocaleMessagesProps {
   pluginApi: PluginApi;


### PR DESCRIPTION
### What does this PR do?
Replaces the plugin api import using absolute path by relative path so that the compiled .d.ts files maintain the correct relative references in the distributed package.

### Closes Issue(s)
Closes #213 

