### PR TITLE
fix: Fix locales and mandatory arguments

### DIFF
--- a/src/core/auxiliary/plugin-information/locale-messages/useLocaleMessages.ts
+++ b/src/core/auxiliary/plugin-information/locale-messages/useLocaleMessages.ts
@@ -47,7 +47,7 @@ function useLocaleMessagesAuxiliary(
         setLoading(false);
       });
     }
-  }, [currentLocale]);
+  }, [localeDataWrapper]);
   return {
     messages,
     loading,

--- a/src/core/auxiliary/plugin-information/locale-messages/useLocaleMessages.ts
+++ b/src/core/auxiliary/plugin-information/locale-messages/useLocaleMessages.ts
@@ -27,8 +27,7 @@ function useLocaleMessagesAuxiliary(
       Promise.all(urlToFetchList.map(async (url) => {
         if (url !== fallbackLocaleUrl || !fallbackMessages) {
           try {
-            const a = await fetchLocaleAndStore(url, fetchConfigs);
-            return a;
+            return await fetchLocaleAndStore(url, fetchConfigs);
           } catch (err) {
             pluginLogger.error(
               `[${pluginApi.pluginName}] - Something went wrong while trying to fetch [${url}] or parse its result: `,

--- a/src/core/auxiliary/plugin-information/locale-messages/utils.ts
+++ b/src/core/auxiliary/plugin-information/locale-messages/utils.ts
@@ -88,12 +88,12 @@ function useGetNormalizedLocale(
         (locale) => locale === localeFromUiData.locale,
       ) !== -1;
 
-      if (isDesiredLocalePresent && localeFromUiData.locale !== currentLocale.data.locale) {
+      if (isDesiredLocalePresent) {
         setCurrentLocale({
           data: localeFromUiData,
           loading: false,
         });
-      } else if (!isDesiredLocalePresent) {
+      } else {
         const regionDefault = usableLocales.find((locale) => locale === desiredLocale[0]);
         const localeFallback = regionDefault || usableLocales[0];
         setCurrentLocale({

--- a/src/core/auxiliary/plugin-information/locale-messages/utils.ts
+++ b/src/core/auxiliary/plugin-information/locale-messages/utils.ts
@@ -106,7 +106,7 @@ function useGetNormalizedLocale(
       }
     } else if (
       !localesIndex.loading
-      && localeFromUiData.locale !== currentLocale.data.locale
+      && localesIndex.error
     ) {
       setCurrentLocale({
         data: localeFromUiData,

--- a/src/extensible-areas/action-button-dropdown-item/component.ts
+++ b/src/extensible-areas/action-button-dropdown-item/component.ts
@@ -35,7 +35,7 @@ export class ActionButtonDropdownOption implements ActionButtonDropdownInterface
    * @returns the option to be displayed in the action button dropdown
    */
   constructor({
-    id, label = '', icon = '', tooltip = '', dataTest = '', allowed = true, onClick = () => {},
+    id, label = '', icon = '', tooltip = '', dataTest = '', allowed = true, onClick = () => { },
   }: ActionButtonDropdownOptionProps) {
     if (id) {
       this.id = id;
@@ -68,7 +68,7 @@ export class ActionButtonDropdownSeparator implements ActionButtonDropdownInterf
    *
    * @returns the separator to be displayed in the action button dropdown
    */
-  constructor({ dataTest = '' }) {
+  constructor({ dataTest = '' } = {}) {
     this.type = ActionButtonDropdownItemType.SEPARATOR;
     this.dataTest = dataTest;
   }

--- a/src/extensible-areas/audio-settings-dropdown-item/component.ts
+++ b/src/extensible-areas/audio-settings-dropdown-item/component.ts
@@ -30,7 +30,7 @@ export class AudioSettingsDropdownOption implements AudioSettingsDropdownInterfa
    * @returns Object that will be interpreted by the core of Bigbluebutton (HTML5)
    */
   constructor({
-    id, label = '', icon = '', dataTest = '', onClick = () => {},
+    id, label = '', icon = '', dataTest = '', onClick = () => { },
   }: AudioSettingsDropdownOptionProps) {
     if (id) {
       this.id = id;
@@ -63,7 +63,8 @@ export class AudioSettingsDropdownSeparator implements AudioSettingsDropdownInte
    *
    * @returns Object that will be interpreted by the core of Bigbluebutton (HTML5)
    */
-  constructor() {
+  constructor({ dataTest = '' } = {}) {
+    this.dataTest = dataTest;
     this.type = AudioSettingsDropdownItemType.SEPARATOR;
   }
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes 2 things:
- Locales were not updating when the desired language is the default;
- Object must be passed in `ActionsButtonDropdownSeparator` constructor's argument breaking backwards compatibility;

### Motivation

Maintain backwards compatibility
