### PR TITLE
ref: rename changeEnforcedLayout to setEnforcedLayout

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,26 +406,35 @@ One other thing is that the type of the return is precisely the same type requir
 
 `uiCommands` object: It basically contains all the possible commands available to the developer to interact with the core BBB UI, see the ones implemented down below:
 
+- actions-bar:
+  - setDisplayActionBar: this function decides whether to display the actions bar
+- camera:
+  - setSelfViewDisableAllDevices: Sets the self-view camera disabled/enabled for all camera devices of a user;
+  - setSelfViewDisable: Sets the self-view camera disabled/enabled for specific camera.
 - chat:
   - form:
     - open: this function will open the sidebar chat panel automatically;
-    - fill: this function will fill the form input field of the chat passed in the argument as {text: string}
+    - fill: this function will fill the form input field of the chat passed in the argument as `{text: string}`
+- conference:
+  - setSpeakerLevel: this function will set the speaker volume level(audio output) of the conference to a certain number between 0 and 1;
 - external-video:
   - volume:
     - set: this function will set the external video volume to a certain number between 0 and 1 (that is 0% and);
-- sidekick-options-container:
-  - open: this function will open the sidekick options panel automatically;
-  - close: this function will close the sidekick options panel automatically (and also the sidebar content if open, to avoid inconsistencies in ui);
+- layout:
+  - changeEnforcedLayout: (deprecated) Changes the enforced layout 
+  - setEnforcedLayout: Sets the enforced layout
+- navBar:
+  - setDisplayNavBar: Sets the displayNavBar to true (show it) or false (hide it).
+- notification:
+  - send: This function will send a notification for the client to render, keep in mind that it's only client-side. Should you want it to be rendered in multiple clients, use this with a data-channel;
 - presentation-area:
   - open: this function will open the presentation area content automatically;
   - close: this function will close the presentation area content automatically;
-- conference:
-  - setSpeakerLevel: this function will set the speaker volume level(audio output) of the conference to a certain number between 0 and 1;
-- notification:
-  - send: This function will send a notification for the client to render, keep in mind that it's only client-side. Should you want it to be rendered in multiple clients, use this with a data-channel;
+- sidekick-options-container:
+  - open: this function will open the sidekick options panel automatically;
+  - close: this function will close the sidekick options panel automatically (and also the sidebar content if open, to avoid inconsistencies in ui);
 - user-status:
   - setAwayStatus: this function will set the away status of the user to a certain status;
-
 See usage ahead:
 
 ```ts

--- a/samples/sample-action-button-dropdown-plugin/src/components/sample-action-button-dropdown-plugin/component.tsx
+++ b/samples/sample-action-button-dropdown-plugin/src/components/sample-action-button-dropdown-plugin/component.tsx
@@ -6,6 +6,7 @@ import {
   ActionButtonDropdownSeparator,
   ActionButtonDropdownOption,
   pluginLogger,
+  ChangeEnforcedLayoutTypeEnum,
 } from 'bigbluebutton-html-plugin-sdk';
 
 import { SampleActionButtonDropdownPluginProps } from './types';
@@ -36,6 +37,61 @@ function SampleActionButtonDropdownPlugin(
           dataTest: 'actionDropdownButtonPlugin',
           onClick: () => {
             pluginLogger.info('Log that the button from sample-action-button-dropdown-plugin has been clicked');
+          },
+        }),
+        new ActionButtonDropdownOption({
+          label: 'Smart layout',
+          icon: 'copy',
+          tooltip: 'this is a button injected by plugin',
+          allowed: true,
+          onClick: () => {
+            pluginApi.uiCommands.layout.changeEnforcedLayout(
+              ChangeEnforcedLayoutTypeEnum.SMART_LAYOUT,
+            );
+          },
+        }),
+        new ActionButtonDropdownOption({
+          label: 'Media Only',
+          icon: 'copy',
+          tooltip: 'this is a button injected by plugin',
+          allowed: true,
+          onClick: () => {
+            pluginApi.uiCommands.layout.changeEnforcedLayout(
+              ChangeEnforcedLayoutTypeEnum.MEDIA_ONLY,
+            );
+          },
+        }),
+        new ActionButtonDropdownOption({
+          label: 'Participants and chat Only',
+          icon: 'copy',
+          tooltip: 'this is a button injected by plugin',
+          allowed: true,
+          onClick: () => {
+            pluginApi.uiCommands.layout.changeEnforcedLayout(
+              ChangeEnforcedLayoutTypeEnum.PARTICIPANTS_AND_CHAT_ONLY,
+            );
+          },
+        }),
+        new ActionButtonDropdownOption({
+          label: 'Presentation Only',
+          icon: 'copy',
+          tooltip: 'this is a button injected by plugin',
+          allowed: true,
+          onClick: () => {
+            pluginApi.uiCommands.layout.changeEnforcedLayout(
+              ChangeEnforcedLayoutTypeEnum.PRESENTATION_ONLY,
+            );
+          },
+        }),
+        new ActionButtonDropdownOption({
+          label: 'Video Focus',
+          icon: 'copy',
+          tooltip: 'this is a button injected by plugin',
+          allowed: true,
+          onClick: () => {
+            pluginApi.uiCommands.layout.changeEnforcedLayout(
+              ChangeEnforcedLayoutTypeEnum.VIDEO_FOCUS,
+            );
           },
         }),
       ]);

--- a/src/ui-commands/actions-bar/commands.ts
+++ b/src/ui-commands/actions-bar/commands.ts
@@ -5,7 +5,7 @@ export const actionsBar = {
   /**
    * Decides whether to display the actions bar
    *
-   * @param setSpeakerLevelCommandArgumentsthe volume to which the core will set the speaker
+   * @param arg object containing the `displayActionBar` which is a boolean
    * level.
    * Refer to {@link SetDisplayActionBarCommandArguments} to understand the argument structure.
    */

--- a/src/ui-commands/conference/commands.ts
+++ b/src/ui-commands/conference/commands.ts
@@ -6,7 +6,7 @@ export const conference = {
    * Sets the volume of the speakers in the conference to a certain level.
    * Needs to be a value between 0 and 1.
    *
-   * @param setSpeakerLevelCommandArgumentsthe volume to which the core will set the speaker
+   * @param setSpeakerLevelCommandArguments volume to which the core will set the speaker
    * level.
    * Refer to {@link SetSpeakerLevelCommandArguments} to understand the argument structure.
    */

--- a/src/ui-commands/index.ts
+++ b/src/ui-commands/index.ts
@@ -1,2 +1,2 @@
 export { NotificationTypeUiCommand } from './notification/enums';
-export { ChangeEnforcedLayoutTypeEnum } from './layout/enums';
+export { ChangeEnforcedLayoutTypeEnum, EnforcedLayoutTypeEnum } from './layout/enums';

--- a/src/ui-commands/layout/commands.ts
+++ b/src/ui-commands/layout/commands.ts
@@ -1,13 +1,14 @@
-import { ChangeEnforcedLayoutTypeEnum, LayoutEnum } from './enums';
-import { ChangeEnforcedLayout, ChangeEnforcedLayoutCommandArguments } from './types';
+import { LayoutEnum, EnforcedLayoutTypeEnum } from './enums';
+import { ChangeEnforcedLayout, ChangeEnforcedLayoutCommandArguments, SetEnforcedLayoutCommandArguments } from './types';
 
 export const layout = {
   /**
-   * <description>
+   * @deprecated Use
+   * Changes The enforced layout
    *
-   * @param
+   * @param layoutType is one of the options described by the enum
    */
-  changeEnforcedLayout: ((layoutType: ChangeEnforcedLayoutTypeEnum) => {
+  changeEnforcedLayout: ((layoutType: EnforcedLayoutTypeEnum) => {
     window.dispatchEvent(
       new CustomEvent<
         ChangeEnforcedLayoutCommandArguments
@@ -18,4 +19,21 @@ export const layout = {
       }),
     );
   }) as ChangeEnforcedLayout,
+
+  /**
+   * Set enforced layout
+   *
+   * @param layoutType is one of the options described by the enum
+   */
+  setEnforcedLayout: ((layoutType: EnforcedLayoutTypeEnum) => {
+    window.dispatchEvent(
+      new CustomEvent<
+        SetEnforcedLayoutCommandArguments
+      >(LayoutEnum.SET_ENFORCED_LAYOUT, {
+        detail: {
+          layoutType,
+        },
+      }),
+    );
+  }),
 };

--- a/src/ui-commands/layout/commands.ts
+++ b/src/ui-commands/layout/commands.ts
@@ -3,8 +3,8 @@ import { ChangeEnforcedLayout, ChangeEnforcedLayoutCommandArguments, SetEnforced
 
 export const layout = {
   /**
-   * @deprecated Use
-   * Changes The enforced layout
+   * @deprecated Use {@link layout.setEnforcedLayout} instead
+   * Changes the enforced layout
    *
    * @param layoutType is one of the options described by the enum
    */
@@ -21,7 +21,7 @@ export const layout = {
   }) as ChangeEnforcedLayout,
 
   /**
-   * Set enforced layout
+   * Sets the enforced layout
    *
    * @param layoutType is one of the options described by the enum
    */

--- a/src/ui-commands/layout/enums.ts
+++ b/src/ui-commands/layout/enums.ts
@@ -1,8 +1,9 @@
 export enum LayoutEnum {
   CHANGE_ENFORCED_LAYOUT = 'CHANGE_ENFORCED_LAYOUT',
+  SET_ENFORCED_LAYOUT = 'SET_ENFORCED_LAYOUT',
 }
 
-export enum ChangeEnforcedLayoutTypeEnum {
+export enum EnforcedLayoutTypeEnum {
   CUSTOM_LAYOUT = 'CUSTOM_LAYOUT',
   SMART_LAYOUT = 'SMART_LAYOUT',
   PRESENTATION_FOCUS = 'PRESENTATION_FOCUS',
@@ -12,3 +13,7 @@ export enum ChangeEnforcedLayoutTypeEnum {
   PARTICIPANTS_AND_CHAT_ONLY = 'PARTICIPANTS_AND_CHAT_ONLY',
   MEDIA_ONLY = 'MEDIA_ONLY',
 }
+
+export const ChangeEnforcedLayoutTypeEnum = EnforcedLayoutTypeEnum;
+
+export type ChangeEnforcedLayoutTypeEnum = EnforcedLayoutTypeEnum;

--- a/src/ui-commands/layout/types.ts
+++ b/src/ui-commands/layout/types.ts
@@ -1,11 +1,18 @@
-import { ChangeEnforcedLayoutTypeEnum } from './enums';
+import { ChangeEnforcedLayoutTypeEnum, EnforcedLayoutTypeEnum } from './enums';
 
 export interface ChangeEnforcedLayoutCommandArguments {
   layoutType: ChangeEnforcedLayoutTypeEnum;
 }
 
+export interface SetEnforcedLayoutCommandArguments {
+  layoutType: EnforcedLayoutTypeEnum;
+}
+
 export type ChangeEnforcedLayout = (layoutType: ChangeEnforcedLayoutTypeEnum) => void;
+
+export type SetEnforcedLayoutFunction = (layoutType: EnforcedLayoutTypeEnum) => void;
 
 export interface UiCommandsLayoutObject {
   changeEnforcedLayout: ChangeEnforcedLayout;
+  setEnforcedLayout: SetEnforcedLayoutFunction;
 }


### PR DESCRIPTION
### What does this PR do?

It renames the previous `pluginApi.uiCommands.layout.changeEnforcedLayout` to `pluginApi.uiCommands.layout.setEnforcedLayout`

### Motivation

This will better align with the current naming we have for the mutations in the CORE

### More

To test it, I'd recommend: 

Add the buttons into the `sample-action-button-dropdown` like so (one can add whatever layout they want there just make sure you can recognize what is changing from one to the other):

```ts
new ActionButtonDropdownOption({
          label: 'Smart layout',
          icon: 'copy',
          tooltip: 'this is a button injected by plugin',
          allowed: true,
          onClick: () => {
            pluginApi.uiCommands.layout.changeEnforcedLayout(
              ChangeEnforcedLayoutTypeEnum.SMART_LAYOUT,
            );
          },
        }),
```
Then run the following:

```bash
# In the SDK:
npm ci
npm run build
./scripts/publish-to-project-folder.sh /path/to/html5/project
```

Then run html5 as development mode and test the current `changeEnforcedLayout` to make sure this PR will not break compatibility;

Once compatibility is tested, go ahead and test the `setEnforcedLayout` ui-command by just publishing the SDK to the samples. and rename the command and the type.

```ts
pluginApi.uiCommands.layout.setEnforcedLayout(
              EnforcedLayoutTypeEnum.SMART_LAYOUT,
            );

```

---

This PR is highly coupled with the PR on the core: https://github.com/bigbluebutton/bigbluebutton/pull/23663

