### PR TITLE
Update required SDK version to ~0.1.5 for all sample plugins

### DIFF
--- a/samples/sample-actions-bar-plugin/manifest.json
+++ b/samples/sample-actions-bar-plugin/manifest.json
@@ -1,5 +1,5 @@
 {
-  "requiredSdkVersion": "~0.0.73",
+  "requiredSdkVersion": "~0.1.5",
   "name": "SampleActionsBarPlugin",
   "javascriptEntrypointUrl": "SampleActionsBarPlugin.js",
   "localesBaseUrl": "https://cdn.dominio.com/pluginabc/"

--- a/samples/sample-apps-gallery-item-plugin/manifest.json
+++ b/samples/sample-apps-gallery-item-plugin/manifest.json
@@ -1,5 +1,5 @@
 {
-  "requiredSdkVersion": "~0.0.70",
+  "requiredSdkVersion": "~0.1.5",
   "name": "SampleAppsGalleryItemPlugin",
   "javascriptEntrypointUrl": "SampleAppsGalleryItemPlugin.js",
   "localesBaseUrl": "https://cdn.dominio.com/pluginabc/"

--- a/samples/sample-audio-settings-dropdown-plugin/manifest.json
+++ b/samples/sample-audio-settings-dropdown-plugin/manifest.json
@@ -1,5 +1,5 @@
 {
-  "requiredSdkVersion": "~0.0.59",
+  "requiredSdkVersion": "~0.1.5",
   "name": "SampleAudioSettingsDropdownPlugin",
   "javascriptEntrypointUrl": "SampleAudioSettingsDropdownPlugin.js",
   "localesBaseUrl": "https://cdn.dominio.com/pluginabc/"

--- a/samples/sample-camera-settings-dropdown-plugin/manifest.json
+++ b/samples/sample-camera-settings-dropdown-plugin/manifest.json
@@ -1,5 +1,5 @@
 {
-  "requiredSdkVersion": "~0.0.59",
+  "requiredSdkVersion": "~0.1.5",
   "name": "SampleCameraSettingsDropdownPlugin",
   "javascriptEntrypointUrl": "SampleCameraSettingsDropdownPlugin.js",
   "localesBaseUrl": "https://cdn.dominio.com/pluginabc/"

--- a/samples/sample-custom-subscription-hook/manifest.json
+++ b/samples/sample-custom-subscription-hook/manifest.json
@@ -1,5 +1,5 @@
 {
-  "requiredSdkVersion": "~0.0.59",
+  "requiredSdkVersion": "~0.1.5",
   "name": "SampleCustomSubscriptionPlugin",
   "javascriptEntrypointUrl": "SampleCustomSubscriptionPlugin.js",
   "localesBaseUrl": "https://cdn.dominio.com/pluginabc/"

--- a/samples/sample-data-channel-plugin/manifest.json
+++ b/samples/sample-data-channel-plugin/manifest.json
@@ -1,13 +1,19 @@
 {
-  "requiredSdkVersion": "~0.0.59",
+  "requiredSdkVersion": "~0.1.5",
   "name": "SampleDataChannelPlugin",
   "javascriptEntrypointUrl": "SampleDataChannelPlugin.js",
   "localesBaseUrl": "https://cdn.dominio.com/pluginabc/",
-  "dataChannels":[
+  "dataChannels": [
     {
       "name": "public-channel",
-      "pushPermission": ["moderator","presenter"],
-      "replaceOrDeletePermission": ["moderator", "sender"]
+      "pushPermission": [
+        "moderator",
+        "presenter"
+      ],
+      "replaceOrDeletePermission": [
+        "moderator",
+        "sender"
+      ]
     }
   ]
 }

--- a/samples/sample-dom-element-manipulation/manifest.json
+++ b/samples/sample-dom-element-manipulation/manifest.json
@@ -1,5 +1,5 @@
 {
-  "requiredSdkVersion": "~0.0.59",
+  "requiredSdkVersion": "~0.1.5",
   "name": "SampleDomElementManipulation",
   "javascriptEntrypointUrl": "SampleDomElementManipulation.js",
   "localesBaseUrl": "https://cdn.dominio.com/pluginabc/"

--- a/samples/sample-floating-window-plugin/manifest.json
+++ b/samples/sample-floating-window-plugin/manifest.json
@@ -1,5 +1,5 @@
 {
-  "requiredSdkVersion": "~0.0.59",
+  "requiredSdkVersion": "~0.1.5",
   "name": "SampleFloatingWindowPlugin",
   "javascriptEntrypointUrl": "SampleFloatingWindowPlugin.js",
   "localesBaseUrl": "https://cdn.dominio.com/pluginabc/"

--- a/samples/sample-generic-content-sidekick-plugin/manifest.json
+++ b/samples/sample-generic-content-sidekick-plugin/manifest.json
@@ -1,5 +1,5 @@
 {
-  "requiredSdkVersion": "~0.0.73",
+  "requiredSdkVersion": "~0.1.5",
   "name": "SampleGenericContentSidekickPlugin",
   "javascriptEntrypointUrl": "SampleGenericContentSidekickPlugin.js",
   "localesBaseUrl": "https://cdn.dominio.com/pluginabc/"

--- a/samples/sample-media-area-plugin/manifest.json
+++ b/samples/sample-media-area-plugin/manifest.json
@@ -1,5 +1,5 @@
 {
-  "requiredSdkVersion": "~0.0.73",
+  "requiredSdkVersion": "~0.1.5",
   "name": "SampleMediaAreaPlugin",
   "javascriptEntrypointUrl": "SampleMediaAreaPlugin.js",
   "localesBaseUrl": "https://cdn.dominio.com/pluginabc/",

--- a/samples/sample-nav-bar-plugin/manifest.json
+++ b/samples/sample-nav-bar-plugin/manifest.json
@@ -1,5 +1,5 @@
 {
-  "requiredSdkVersion": "~0.0.59",
+  "requiredSdkVersion": "~0.1.5",
   "name": "SampleNavBarPlugin",
   "javascriptEntrypointUrl": "SampleNavBarPlugin.js",
   "localesBaseUrl": "https://cdn.dominio.com/pluginabc/"

--- a/samples/sample-options-dropdown-plugin/manifest.json
+++ b/samples/sample-options-dropdown-plugin/manifest.json
@@ -1,5 +1,5 @@
 {
-  "requiredSdkVersion": "~0.0.59",
+  "requiredSdkVersion": "~0.1.5",
   "name": "SampleOptionsDropdownPlugin",
   "javascriptEntrypointUrl": "SampleOptionsDropdownPlugin.js",
   "localesBaseUrl": "https://cdn.dominio.com/pluginabc/"

--- a/samples/sample-presentation-dropdown-plugin/manifest.json
+++ b/samples/sample-presentation-dropdown-plugin/manifest.json
@@ -1,5 +1,5 @@
 {
-  "requiredSdkVersion": "~0.0.59",
+  "requiredSdkVersion": "~0.1.5",
   "name": "SamplePresentationDropdownPlugin",
   "javascriptEntrypointUrl": "SamplePresentationDropdownPlugin.js",
   "localesBaseUrl": "https://cdn.dominio.com/pluginabc/"

--- a/samples/sample-presentation-toolbar-plugin/manifest.json
+++ b/samples/sample-presentation-toolbar-plugin/manifest.json
@@ -1,5 +1,5 @@
 {
-  "requiredSdkVersion": "~0.0.59",
+  "requiredSdkVersion": "~0.1.5",
   "name": "SamplePresentationToolbarPlugin",
   "javascriptEntrypointUrl": "SamplePresentationToolbarPlugin.js",
   "localesBaseUrl": "https://cdn.dominio.com/pluginabc/"

--- a/samples/sample-screenshare-helper-plugin/manifest.json
+++ b/samples/sample-screenshare-helper-plugin/manifest.json
@@ -1,5 +1,5 @@
 {
-  "requiredSdkVersion": "~0.0.59",
+  "requiredSdkVersion": "~0.1.5",
   "name": "SampleScreenshareHelperPlugin",
   "javascriptEntrypointUrl": "SampleScreenshareHelperPlugin.js",
   "localesBaseUrl": "https://cdn.dominio.com/pluginabc/"

--- a/samples/sample-server-commands-plugin/manifest.json
+++ b/samples/sample-server-commands-plugin/manifest.json
@@ -1,5 +1,5 @@
 {
-  "requiredSdkVersion": "~0.0.59",
+  "requiredSdkVersion": "~0.1.5",
   "name": "SampleServerCommandsPlugin",
   "javascriptEntrypointUrl": "SampleServerCommandsPlugin.js",
   "localesBaseUrl": "https://cdn.dominio.com/pluginabc/"

--- a/samples/sample-ui-commands-plugin/manifest.json
+++ b/samples/sample-ui-commands-plugin/manifest.json
@@ -1,5 +1,5 @@
 {
-  "requiredSdkVersion": "~0.0.59",
+  "requiredSdkVersion": "~0.1.5",
   "name": "SampleUiCommandsPlugin",
   "javascriptEntrypointUrl": "SampleUiCommandsPlugin.js",
   "localesBaseUrl": "https://cdn.dominio.com/pluginabc/"

--- a/samples/sample-ui-events-plugin/manifest.json
+++ b/samples/sample-ui-events-plugin/manifest.json
@@ -1,5 +1,5 @@
 {
-  "requiredSdkVersion": "~0.0.59",
+  "requiredSdkVersion": "~0.1.5",
   "name": "SampleUiEventsPlugin",
   "javascriptEntrypointUrl": "SampleUiEventsPlugin.js",
   "localesBaseUrl": "https://cdn.dominio.com/pluginabc/"

--- a/samples/sample-use-meeting/manifest.json
+++ b/samples/sample-use-meeting/manifest.json
@@ -1,9 +1,9 @@
 {
-  "requiredSdkVersion": "~0.0.59",
+  "requiredSdkVersion": "~0.1.5",
   "name": "SampleUseMeeting",
   "javascriptEntrypointUrl": "SampleUseMeeting.js",
   "localesBaseUrl": "https://cdn.dominio.com/pluginabc/",
   "eventPersistence": {
-      "isEnabled": true
+    "isEnabled": true
   }
 }

--- a/samples/sample-user-camera-dropdown-plugin/manifest.json
+++ b/samples/sample-user-camera-dropdown-plugin/manifest.json
@@ -1,5 +1,5 @@
 {
-  "requiredSdkVersion": "~0.0.59",
+  "requiredSdkVersion": "~0.1.5",
   "name": "SampleUserCameraDropdownPlugin",
   "javascriptEntrypointUrl": "SampleUserCameraDropdownPlugin.js",
   "localesBaseUrl": "https://cdn.dominio.com/pluginabc/"

--- a/samples/sample-user-camera-helper-plugin/manifest.json
+++ b/samples/sample-user-camera-helper-plugin/manifest.json
@@ -1,5 +1,5 @@
 {
-  "requiredSdkVersion": "~0.0.73",
+  "requiredSdkVersion": "~0.1.5",
   "name": "SampleUserCameraHelperPlugin",
   "javascriptEntrypointUrl": "SampleUserCameraHelperPlugin.js",
   "localesBaseUrl": "https://cdn.dominio.com/pluginabc/"

--- a/samples/sample-user-list-dropdown-plugin/manifest.json
+++ b/samples/sample-user-list-dropdown-plugin/manifest.json
@@ -1,5 +1,5 @@
 {
-  "requiredSdkVersion": "~0.0.59",
+  "requiredSdkVersion": "~0.1.5",
   "name": "SampleUserListDropdownPlugin",
   "javascriptEntrypointUrl": "SampleUserListDropdownPlugin.js",
   "localesBaseUrl": "https://cdn.dominio.com/pluginabc/"

--- a/samples/sample-user-list-item-additional-information-plugin/manifest.json
+++ b/samples/sample-user-list-item-additional-information-plugin/manifest.json
@@ -1,5 +1,5 @@
 {
-  "requiredSdkVersion": "~0.0.59",
+  "requiredSdkVersion": "~0.1.5",
   "name": "SampleUserListItemAdditionalInformationPlugin",
   "javascriptEntrypointUrl": "SampleUserListItemAdditionalInformationPlugin.js",
   "localesBaseUrl": "https://cdn.dominio.com/pluginabc/"


### PR DESCRIPTION
### What does this PR do?

I've been facing errors when loading samples in v3.1 sessions due to the wrong `requiredSdkVersion` value in the manifest files. This PR updates this value for all sample plugins, matching the current `html5PluginSdkVersion` in `bigbluebutton.properties`. Tested locally and worked properly