### PR TITLE
ref: Added information to useUsersBasicInfo and ordered the results

### DIFF
--- a/src/data-consumption/domain/users/index.ts
+++ b/src/data-consumption/domain/users/index.ts
@@ -8,4 +8,5 @@ export {
 
 export {
   UsersBasicInfoResponseFromGraphqlWrapper,
+  UsersBasicInfoData,
 } from './users-basic-info/types';

--- a/src/data-consumption/domain/users/users-basic-info/hooks.ts
+++ b/src/data-consumption/domain/users/users-basic-info/hooks.ts
@@ -1,8 +1,8 @@
-import { useCustomSubscription } from '../../shared/custom-subscription/hooks';
-import { USERS_BASIC_INFO_QUERY } from './queries';
+import { DataConsumptionHooks } from '../../../../data-consumption/enums';
+import { createDataConsumptionHook } from '../../../factory/hookCreator';
 import { UsersBasicInfoResponseFromGraphqlWrapper } from './types';
 
-export const useUsersBasicInfo = () => useCustomSubscription<
+export const useUsersBasicInfo = () => createDataConsumptionHook<
   UsersBasicInfoResponseFromGraphqlWrapper>(
-    USERS_BASIC_INFO_QUERY,
+    DataConsumptionHooks.USERS_BASIC_INFO,
   );

--- a/src/data-consumption/domain/users/users-basic-info/queries.ts
+++ b/src/data-consumption/domain/users/users-basic-info/queries.ts
@@ -1,8 +1,0 @@
-export const USERS_BASIC_INFO_QUERY = `
-subscription Users {
-  user {
-    userId
-    name
-    role
-  }
-}`;

--- a/src/data-consumption/domain/users/users-basic-info/types.ts
+++ b/src/data-consumption/domain/users/users-basic-info/types.ts
@@ -2,8 +2,13 @@ import { GraphqlResponseWrapper } from '../../../../core';
 
 export interface UsersBasicInfoData {
   userId: string;
+  extId: string;
   name: string;
   role: string;
+  avatar: string;
+  color: string;
+  isModerator: boolean;
+  presenter: boolean;
 }
 
 export interface UsersBasicInfoResponseFromGraphqlWrapper {

--- a/src/data-consumption/domain/users/users-basic-info/types.ts
+++ b/src/data-consumption/domain/users/users-basic-info/types.ts
@@ -4,6 +4,9 @@ export interface UsersBasicInfoData {
   userId: string;
   extId: string;
   name: string;
+  /**
+   * @deprecated use {@link isModerator} instead
+   */
   role: string;
   avatar: string;
   color: string;

--- a/src/data-consumption/enums.ts
+++ b/src/data-consumption/enums.ts
@@ -2,6 +2,7 @@ export enum DataConsumptionHooks {
   CURRENT_PRESENTATION = 'Hooks::UseCurrentPresentation',
   LOADED_USER_LIST = 'Hooks::UseLoadedUserList',
   CURRENT_USER = 'Hooks::UseCurrentUser',
+  USERS_BASIC_INFO = 'Hooks::UseUsersBasicInfo',
   LOADED_CHAT_MESSAGES = 'Hooks::UseLoadedChatMessages',
   MEETING = 'Hooks::UseMeeting',
   TALKING_INDICATOR = 'Hooks::UseTalkingIndicator',


### PR DESCRIPTION
### What does this PR do?

This PR adds new information and ordering to the hook useUsersInformation. As for the other currently supported SDK data consumption hooks, adding ordering was sometimes not possible and other times, it doesn't make sense, see below:
- useLoadedChatMessages: paginated and ordered;
- useMeeting: only one entry of data;
- useCurrentPresentation: again, only one entry of data for both the page, and the presentation;
- useTalkingIndicator: it's a stream and needs to be in the order that it's already set;
- useCurrentUser: Only one entry is returned;
- useLoadedUserlist: Already ordered;

### Closes Issue(s)

Closes #206

### Motivation

This PR should help in cases such as this pick-random-user issue: https://github.com/bigbluebutton/plugin-pick-random-user/issues/57;

Despite that, since we added extra information in the hook, if we update the plugin with the new `useUsersBasicInfo`, the next version of pick-random-user will not be backward compatible with previous versions of BBB, only newer ones. The solution will be to maintain the previous custom-hook into the pick-random-user with a new ordering for bbb v3.0.x and for v3.1.x we can include this new function as 3.1 is not released just yet.

### More

Closely related to CORE PR: https://github.com/bigbluebutton/bigbluebutton/pull/23688