### PR TITLE
feat: add new PLUGINS_ONLY layout type

### DIFF
--- a/samples/sample-action-button-dropdown-plugin/src/components/sample-action-button-dropdown-plugin/component.tsx
+++ b/samples/sample-action-button-dropdown-plugin/src/components/sample-action-button-dropdown-plugin/component.tsx
@@ -84,14 +84,30 @@ function SampleActionButtonDropdownPlugin(
           },
         }),
         new ActionButtonDropdownOption({
-          label: 'Video Focus',
+          label: 'Cameras Only',
           icon: 'copy',
           tooltip: 'this is a button injected by plugin',
           allowed: true,
           onClick: () => {
             pluginApi.uiCommands.layout.changeEnforcedLayout(
-              ChangeEnforcedLayoutTypeEnum.VIDEO_FOCUS,
+              ChangeEnforcedLayoutTypeEnum.CAMERAS_ONLY,
             );
+          },
+        }),
+        new ActionButtonDropdownOption({
+          label: 'Plugins only',
+          icon: 'copy',
+          tooltip: 'this is a button injected by plugin',
+          allowed: true,
+          onClick: () => {
+            pluginApi.uiCommands.layout.changeEnforcedLayout(
+              ChangeEnforcedLayoutTypeEnum.PLUGINS_ONLY,
+            );
+            setTimeout(() => {
+              pluginApi.uiCommands.layout.changeEnforcedLayout(
+                ChangeEnforcedLayoutTypeEnum.SMART_LAYOUT,
+              );
+            }, 5000);
           },
         }),
       ]);

--- a/src/ui-commands/layout/enums.ts
+++ b/src/ui-commands/layout/enums.ts
@@ -4,6 +4,7 @@ export enum LayoutEnum {
 }
 
 export enum EnforcedLayoutTypeEnum {
+  PLUGINS_ONLY = 'PLUGINS_ONLY',
   CUSTOM_LAYOUT = 'CUSTOM_LAYOUT',
   SMART_LAYOUT = 'SMART_LAYOUT',
   PRESENTATION_FOCUS = 'PRESENTATION_FOCUS',


### PR DESCRIPTION
### What does this PR do?

It adds a new layout type called `PLUGINS_ONLY` which basically removes everything from bbb's layout except for the plugins.

### Closes Issue(s)

Closes #23588

### Motivation

Some plugins can benefit from it when used along with the getJoinUrl function, so that one can render an interface as different as they want, while having access to every other feature from BBB that the plugin has access (publishing data/retrieving data).

### How to test

In the SDK's PR, I added a few lines of code to change from one layout type to another in the Sample-action-button-dorpdown-items  

### More

Closely related to https://github.com/bigbluebutton/bigbluebutton/pull/23696

See a little demo ahead (mind that after the plugin set the layout to `PLUGINS_ONLY`, it then starts a timeout to restore back to a known layout - one can test the restoration back to any other layout).

https://github.com/user-attachments/assets/60139374-2324-49f5-bb04-d3f71f4a659f

