### PR TITLE
feat: added more fields to useMeeting hook and created a projection feature 

### DIFF
--- a/src/core/api/BbbPluginSdk.ts
+++ b/src/core/api/BbbPluginSdk.ts
@@ -56,6 +56,8 @@ import { useCustomQuery } from '../../data-consumption/domain/shared/custom-quer
 import { UseCustomQueryFunction } from '../../data-consumption/domain/shared/custom-query/types';
 import { useCustomMutation } from '../../data-creation/hook';
 import { UseCustomMutationFunction } from '../../data-creation/types';
+import { UseMeetingDataFunction } from '../../data-consumption/domain/meeting/meeting-data/types';
+import { useMeetingData } from '../../data-consumption/domain/meeting/meeting-data/hooks';
 
 declare const window: PluginBrowserWindow;
 
@@ -98,6 +100,7 @@ export abstract class BbbPluginSdk {
     pluginApi.useLoadedUserList = (() => useLoadedUserList()) as UseLoadedUserListFunction;
     pluginApi.useCurrentUser = (() => useCurrentUser()) as UseCurrentUserFunction;
     pluginApi.useMeeting = (() => useMeeting()) as UseMeetingFunction;
+    pluginApi.useMeetingData = useMeetingData as UseMeetingDataFunction;
     pluginApi.useUsersBasicInfo = (() => useUsersBasicInfo()) as UseUsersBasicInfoFunction;
     pluginApi.useTalkingIndicator = (() => useTalkingIndicator()) as UseTalkingIndicatorFunction;
     pluginApi.getJoinUrl = (params) => getJoinUrl(params);

--- a/src/core/api/types.ts
+++ b/src/core/api/types.ts
@@ -37,6 +37,7 @@ import { UseShouldUnmountPluginFunction } from '../auxiliary/plugin-unmount/type
 import { GetUiDataFunction } from '../../ui-data/getters/types';
 import { UseCustomQueryFunction } from '../../data-consumption/domain/shared/custom-query/types';
 import { UseCustomMutationFunction } from '../../data-creation/types';
+import { UseMeetingDataFunction } from '../../data-consumption/domain/meeting/meeting-data/types';
 
 // Setter Functions for the API
 export type SetPresentationToolbarItems = (presentationToolbarItem:
@@ -147,8 +148,21 @@ export interface PluginApi {
    *
    * @returns `GraphqlResponseWrapper` with the CurrentMeeting type.
    *
+   * @deprecated use {@link useMeetingData}
+   *
    */
   useMeeting?: UseMeetingFunction;
+  /**
+   * Returns an object containing the data on the current meeting, i.e. the meeting on which the
+   * plugin is running.
+   *
+   * @param projectionFunction - function to select only specific fields from the
+   *  Meeting type (Optional - if not provided, returns all fields).
+   *
+   * @returns `GraphqlResponseWrapper` with the CurrentMeeting type.
+   *
+   */
+  useMeetingData?: UseMeetingDataFunction;
   /**
    * Returns an object containing the brief data on every user in te meeting.
    *

--- a/src/data-consumption/domain/meeting/index.ts
+++ b/src/data-consumption/domain/meeting/index.ts
@@ -1,1 +1,2 @@
 export { Meeting } from './from-core/types';
+export { MeetingData } from './meeting-data/types';

--- a/src/data-consumption/domain/meeting/meeting-data/hooks.ts
+++ b/src/data-consumption/domain/meeting/meeting-data/hooks.ts
@@ -1,0 +1,16 @@
+import { DeepPartial } from '../../../../data-consumption/factory/types';
+import { useProjectedValue } from '../../../../data-consumption/factory/hooks';
+import { DataConsumptionHooks } from '../../../enums';
+import { createDataConsumptionHook } from '../../../factory/hookCreator';
+import { MeetingData } from './types';
+
+export const useMeetingData = (
+  projectionFunction?: (q: MeetingData) => DeepPartial<MeetingData>,
+) => useProjectedValue<MeetingData>(
+  createDataConsumptionHook<
+    MeetingData
+  >(
+    DataConsumptionHooks.MEETING_DATA,
+  ),
+  projectionFunction,
+);

--- a/src/data-consumption/domain/meeting/meeting-data/types.ts
+++ b/src/data-consumption/domain/meeting/meeting-data/types.ts
@@ -1,0 +1,154 @@
+import { DeepPartial } from '../../../../data-consumption/factory/types';
+import { GraphqlResponseWrapper } from '../../../../core';
+
+export interface LockSettings {
+  disableCam: boolean;
+  disableMic: boolean;
+  disableNotes: boolean;
+  disablePrivateChat: boolean;
+  disablePublicChat: boolean;
+  hasActiveLockSetting: boolean;
+  hideUserList: boolean;
+  hideViewersCursor: boolean;
+  hideViewersAnnotation: false,
+  meetingId: boolean;
+  webcamsOnlyForModerator: boolean;
+}
+
+export interface groups {
+  groupId: string;
+  name: string;
+}
+
+export interface WelcomeSettings {
+  welcomeMsg: string;
+  welcomeMsgForModerators: string;
+  meetingId: string;
+}
+
+export interface MeetingRecording {
+  isRecording: boolean;
+  startedAt: Date;
+  previousRecordedTimeInSeconds: number;
+  startedBy: string;
+  stoppedAt: number;
+  stoppedBy: string;
+}
+export interface MeetingRecordingPolicies {
+  allowStartStopRecording: boolean;
+  autoStartRecording: boolean;
+  record: boolean;
+  keepEvents: boolean;
+  startedAt: number;
+  startedBy: string;
+  stoppedAt: number;
+  stoppedBy: string;
+}
+
+export interface UsersPolicies {
+  allowModsToEjectCameras: boolean;
+  allowModsToUnmuteUsers: boolean;
+  authenticatedGuest: boolean;
+  allowPromoteGuestToModerator: boolean;
+  guestPolicy: string;
+  maxUserConcurrentAccesses: number;
+  maxUsers: number;
+  meetingId: string;
+  meetingLayout: string;
+  userCameraCap: number;
+  webcamsOnlyForModerator: boolean;
+  guestLobbyMessage: string | null;
+}
+
+export interface VoiceSettings {
+  dialNumber: string;
+  meetingId: string;
+  muteOnStart: boolean;
+  telVoice: string;
+  voiceConf: string;
+}
+
+export interface BreakoutPolicies {
+  breakoutRooms: Array<unknown>;
+  captureNotes: string;
+  captureNotesFilename: string;
+  captureSlides: string;
+  captureSlidesFilename: string;
+  freeJoin: boolean;
+  parentId: string;
+  privateChatEnabled: boolean;
+  record: boolean;
+  sequence: number;
+}
+
+export interface BreakoutRoomsCommonProperties {
+  durationInSeconds: number;
+  freeJoin: boolean;
+  sendInvitationToModerators: boolean;
+  startedAt: Date;
+}
+
+export interface ExternalVideo {
+  externalVideoId: string;
+  playerCurrentTime: number;
+  playerPlaybackRate: number;
+  playerPlaying: boolean;
+  externalVideoUrl: string;
+  startedSharingAt: number;
+  stoppedSharingAt: number;
+  updatedAt: string;
+}
+
+export interface Layout {
+  currentLayoutType: string;
+}
+
+export interface ComponentsFlags {
+  hasCaption: boolean;
+  hasBreakoutRoom: boolean;
+  hasExternalVideo: boolean;
+  hasPoll: boolean;
+  hasScreenshare: boolean;
+  hasTimer: boolean;
+  showRemainingTime: boolean;
+  hasCameraAsContent: boolean;
+  hasScreenshareAsContent: boolean;
+  hasCurrentPresentation: boolean;
+  hasSharedNotes: boolean;
+  isSharedNotesPinned: boolean;
+}
+
+export interface MeetingData {
+  createdTime: number;
+  disabledFeatures: Array<string>;
+  durationInSeconds: number;
+  extId: string;
+  isBreakout: boolean;
+  learningDashboardAccessToken: string;
+  maxPinnedCameras: number;
+  meetingCameraCap: number;
+  cameraBridge: string;
+  screenShareBridge: string;
+  audioBridge: string;
+  meetingId: string;
+  name: string;
+  notifyRecordingIsOn: boolean;
+  presentationUploadExternalDescription: string;
+  presentationUploadExternalUrl: string;
+  usersPolicies: UsersPolicies;
+  lockSettings: LockSettings;
+  voiceSettings: VoiceSettings;
+  breakoutPolicies: BreakoutPolicies;
+  breakoutRoomsCommonProperties: BreakoutRoomsCommonProperties;
+  externalVideo: ExternalVideo;
+  layout: Layout;
+  componentsFlags: ComponentsFlags;
+  endWhenNoModerator: boolean;
+  endWhenNoModeratorDelayInMinutes: number;
+  loginUrl: string | null;
+  groups: Array<groups>;
+}
+
+export type UseMeetingDataFunction = (
+  projectionFunction?: (q: MeetingData) => DeepPartial<MeetingData>,
+) => GraphqlResponseWrapper<MeetingData>;

--- a/src/data-consumption/enums.ts
+++ b/src/data-consumption/enums.ts
@@ -5,6 +5,7 @@ export enum DataConsumptionHooks {
   USERS_BASIC_INFO = 'Hooks::UseUsersBasicInfo',
   LOADED_CHAT_MESSAGES = 'Hooks::UseLoadedChatMessages',
   MEETING = 'Hooks::UseMeeting',
+  MEETING_DATA = 'Hooks::UseMeetingData',
   TALKING_INDICATOR = 'Hooks::UseTalkingIndicator',
   CUSTOM_SUBSCRIPTION = 'Hooks::CustomSubscription',
   CUSTOM_QUERY = 'Hooks::CustomQuery',

--- a/src/data-consumption/factory/hooks.ts
+++ b/src/data-consumption/factory/hooks.ts
@@ -1,0 +1,82 @@
+import {
+  useRef,
+  useMemo,
+  useEffect,
+  useState,
+} from 'react';
+import { sortedStringify } from '../utils';
+import { GraphqlResponseWrapper } from '../../core';
+import { hasErrorChanged } from './utils';
+import { DeepPartial } from './types';
+
+// Function overload for array type
+export function useProjectedValue<TQueryResult>(
+  queryResult: GraphqlResponseWrapper<TQueryResult[]>,
+  project?: (q: TQueryResult) => DeepPartial<TQueryResult>,
+): GraphqlResponseWrapper<TQueryResult[]> | GraphqlResponseWrapper<DeepPartial<TQueryResult>[]>;
+// Function overload for single value type
+export function useProjectedValue<TQueryResult>(
+  queryResult: GraphqlResponseWrapper<TQueryResult>,
+  project?: (q: TQueryResult) => DeepPartial<TQueryResult>,
+): GraphqlResponseWrapper<TQueryResult> | GraphqlResponseWrapper<DeepPartial<TQueryResult>>;
+// Implementation
+export function useProjectedValue<TQueryResult>(
+  queryResult: GraphqlResponseWrapper<TQueryResult[] | TQueryResult>,
+  project?: (q: TQueryResult) => DeepPartial<TQueryResult>,
+): GraphqlResponseWrapper<TQueryResult[] | TQueryResult>
+  | GraphqlResponseWrapper<DeepPartial<TQueryResult>[] | DeepPartial<TQueryResult>> {
+  if (!project) return queryResult;
+
+  const isArray = Array.isArray(queryResult.data);
+
+  // Store the previous projected data to compare against
+  const previousProjectedDataRef = useRef<
+    DeepPartial<TQueryResult>[] | DeepPartial<TQueryResult> | undefined
+  >(undefined);
+
+  // Compute the new projected value from the data field
+  const currentProjectedData = useMemo(() => {
+    if (!queryResult.data) return undefined;
+    if (isArray) {
+      return (queryResult.data as TQueryResult[]).map((item) => project(item));
+    }
+    return project(queryResult.data as TQueryResult);
+  }, [queryResult.data, project, isArray]);
+
+  // Initialize state with the wrapper structure
+  const [projectionResult, setProjectionResult] = useState<
+    GraphqlResponseWrapper<DeepPartial<TQueryResult>[] | DeepPartial<TQueryResult>>
+  >({
+    loading: queryResult.loading,
+    data: currentProjectedData,
+    error: queryResult.error,
+  });
+
+  useEffect(() => {
+    // Perform deep equality check using sortedStringify
+    const currentSerialized = sortedStringify(currentProjectedData);
+    const previousSerialized = sortedStringify(previousProjectedDataRef.current);
+
+    // Check if loading or error states changed
+    const loadingChanged = queryResult.loading !== projectionResult.loading;
+    const errorChanged = hasErrorChanged(projectionResult.error, queryResult.error);
+
+    // Only update if the projected data, loading, or error state has changed
+    if (currentSerialized !== previousSerialized || loadingChanged || errorChanged) {
+      previousProjectedDataRef.current = currentProjectedData;
+      setProjectionResult({
+        loading: queryResult.loading,
+        data: currentProjectedData,
+        error: queryResult.error,
+      });
+    }
+  }, [
+    currentProjectedData,
+    queryResult.loading,
+    queryResult.error,
+    projectionResult.loading,
+    projectionResult.error,
+  ]);
+
+  return projectionResult;
+}

--- a/src/data-consumption/factory/types.ts
+++ b/src/data-consumption/factory/types.ts
@@ -1,0 +1,7 @@
+export type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends (infer U)[]
+  ? DeepPartial<U>[]
+  : T[K] extends object
+  ? DeepPartial<T[K]>
+  : T[K];
+};

--- a/src/data-consumption/factory/utils.ts
+++ b/src/data-consumption/factory/utils.ts
@@ -1,0 +1,11 @@
+import { ApolloError } from '@apollo/client';
+import { sortedStringify } from '../utils';
+
+export const hasErrorChanged = (
+  previousResultError?: ApolloError,
+  currentResultError?: ApolloError,
+) => {
+  const currentSerialized = sortedStringify(currentResultError);
+  const previousSerialized = sortedStringify(previousResultError);
+  return currentSerialized !== previousSerialized;
+};

--- a/src/data-consumption/index.ts
+++ b/src/data-consumption/index.ts
@@ -4,3 +4,5 @@ export * from './domain/meeting';
 export * from './domain/users';
 export * from './domain/user-voice';
 export * from './domain/shared';
+
+export * from './factory/types';


### PR DESCRIPTION
### What does this PR do?

This PR introduces a new **data projection and consumption factory pattern** for the BigBlueButton HTML Plugin SDK. The main changes include (for now, only used with useMeeting, but we can easily apply the same to other hooks):

- Increase the total number of poossible fields available to be fetched in useMeetingData hook;
- Deprecates `useMeeting` hook in favour of `useMeetingData` hook;
- Creates a new projection pattern to only select the fields one wants for a specific data-consumption hook (in this case only applied for the useMeeting, for now); 

### Motivation

The current approach has 2 main problems:

- **Lacks fields when necessary:** So if the developer wants to use the components flags, for example, right now that's not possible;
- **Too many fields:** On the other hand, if we make every field available for the user, that could lead to performance issues;

### More

Closely related to PR https://github.com/bigbluebutton/bigbluebutton/pull/24351

**Testing Recommendations:**
For testing, I'd recommend create 2 instances of the same hook in a plugin with different data, for example:

```tsx

  const { data } = pluginApi.useMeetingData((m) => ({
    componentsFlags: {
      hasPoll: m.componentsFlags.hasPoll,
      hasExternalVideo: m.componentsFlags.hasExternalVideo,
    }
  }));

  const { data: data2 } = pluginApi.useMeetingData((m) => ({
    meetingId: m.meetingId,
    name: m.name,
  }));

  useEffect(() => {
    console.log('Log for the first selection ---> :', data);
  }, [data]);

  useEffect(() => {
    console.log('Log for the first selection ---> :', data2);
  }, [data2]);
```

In the console, if you share an external video, that should only trigger "Log for the first selection --->"
