### PR TITLE
feat(actions-bar): add color property to ActionsBarButton

### DIFF
--- a/src/extensible-areas/actions-bar-item/component.ts
+++ b/src/extensible-areas/actions-bar-item/component.ts
@@ -46,6 +46,8 @@ export class ActionsBarButton extends ActionsBarItem {
 
   onClick: () => void;
 
+  color: string;
+
   /**
    * Returns object to be used in the setter for action bar. In this case,
    * a button.
@@ -56,11 +58,13 @@ export class ActionsBarButton extends ActionsBarItem {
    * @param dataTest - string attribute to be used for testing
    * @param onClick - function to be called when clicking the button
    * @param position - position that this button will be displayed, see {@link ActionsBarPosition}
+   * @param color - button color variant, defaults to 'primary'
    *
    * @returns Object that will be interpreted by the core of Bigbluebutton (HTML5)
    */
   constructor({
     id, icon, tooltip = '', dataTest = '', onClick = () => {}, position = ActionsBarPosition.RIGHT,
+    color = 'primary',
   }: ActionsBarButtonProps) {
     super({
       id, type: ActionsBarItemType.BUTTON, position, dataTest,
@@ -69,6 +73,7 @@ export class ActionsBarButton extends ActionsBarItem {
     this.tooltip = tooltip;
     this.dataTest = dataTest;
     this.onClick = onClick;
+    this.color = color;
   }
 }
 

--- a/src/extensible-areas/actions-bar-item/types.ts
+++ b/src/extensible-areas/actions-bar-item/types.ts
@@ -36,6 +36,7 @@ export interface ActionsBarButtonProps {
   position: ActionsBarPosition;
   dataTest?: string;
   onClick: () => void;
+  color?: string;
 }
 
 export interface ActionsBarSeparatorProps {


### PR DESCRIPTION
## Summary

- Add optional `color` property to `ActionsBarButtonProps` and `ActionsBarButton`
- Defaults to `'primary'` for backward compatibility
- Follows the same pattern as `textColor` in `UserListDropdownInformation` and `backgroundColor` in `FloatingWindow`

## Motivation

Companion change to bigbluebutton/bigbluebutton#24719, which reads `plugin.color` in the HTML5 client's actions bar rendering. Without this SDK change, plugins must cast to `any` to set the color property.

Use case: a remote desktop plugin uses button color to indicate lock/unlock state — blue (`'primary'`) when unlocked, neutral (`'default'`) when locked.

## Test plan

- [ ] Existing plugins that don't set `color` should be unaffected (defaults to `'primary'`)
- [ ] A plugin setting `color: 'default'` should pass the value through to the HTML5 client

---
*This PR was researched and written by an AI assistant (Claude) on behalf of Brent Baccala (cosine@freesoft.org), based on a review request from @GuiLeme on bigbluebutton/bigbluebutton#24719.*