### PR TITLE
feat: Add svg icon for all extensible areas

### DIFF
--- a/samples/sample-generic-content-sidekick-plugin/src/components/sample-generic-content-sidekick-plugin-item/component.tsx
+++ b/samples/sample-generic-content-sidekick-plugin/src/components/sample-generic-content-sidekick-plugin-item/component.tsx
@@ -11,6 +11,18 @@ import * as ReactDOM from 'react-dom/client';
 import { SampleGenericContentSidekickPluginProps } from './types';
 import { GenericContentSidekickExample } from '../generic-content-sidekick-example/component';
 
+const BatteryIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1}
+    stroke="currentColor"
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="M21 10.5h.375c.621 0 1.125.504 1.125 1.125v2.25c0 .621-.504 1.125-1.125 1.125H21M4.5 10.5H18V15H4.5v-4.5ZM3.75 18h15A2.25 2.25 0 0 0 21 15.75v-6a2.25 2.25 0 0 0-2.25-2.25h-15A2.25 2.25 0 0 0 1.5 9.75v6A2.25 2.25 0 0 0 3.75 18Z" />
+  </svg>
+);
+
 function SampleGenericContentSidekickPlugin(
   { pluginUuid: uuid }: SampleGenericContentSidekickPluginProps,
 ): React.ReactNode {
@@ -28,7 +40,9 @@ function SampleGenericContentSidekickPlugin(
         name: 'Generic Content 1',
         section: 'Section 1',
         dataTest: 'section-1-generic-content-sidekick-abc',
-        buttonIcon: 'video',
+        buttonIcon: {
+          svgContent: <BatteryIcon />
+        },
         open: false,
         contentFunction: (element: HTMLElement) => {
           const root = ReactDOM.createRoot(element);

--- a/samples/sample-generic-content-sidekick-plugin/src/components/sample-generic-content-sidekick-plugin-item/component.tsx
+++ b/samples/sample-generic-content-sidekick-plugin/src/components/sample-generic-content-sidekick-plugin-item/component.tsx
@@ -11,17 +11,19 @@ import * as ReactDOM from 'react-dom/client';
 import { SampleGenericContentSidekickPluginProps } from './types';
 import { GenericContentSidekickExample } from '../generic-content-sidekick-example/component';
 
-const BatteryIcon = () => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    strokeWidth={1}
-    stroke="currentColor"
-  >
-    <path strokeLinecap="round" strokeLinejoin="round" d="M21 10.5h.375c.621 0 1.125.504 1.125 1.125v2.25c0 .621-.504 1.125-1.125 1.125H21M4.5 10.5H18V15H4.5v-4.5ZM3.75 18h15A2.25 2.25 0 0 0 21 15.75v-6a2.25 2.25 0 0 0-2.25-2.25h-15A2.25 2.25 0 0 0 1.5 9.75v6A2.25 2.25 0 0 0 3.75 18Z" />
-  </svg>
-);
+function BatteryIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1}
+      stroke="currentColor"
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M21 10.5h.375c.621 0 1.125.504 1.125 1.125v2.25c0 .621-.504 1.125-1.125 1.125H21M4.5 10.5H18V15H4.5v-4.5ZM3.75 18h15A2.25 2.25 0 0 0 21 15.75v-6a2.25 2.25 0 0 0-2.25-2.25h-15A2.25 2.25 0 0 0 1.5 9.75v6A2.25 2.25 0 0 0 3.75 18Z" />
+    </svg>
+  );
+}
 
 function SampleGenericContentSidekickPlugin(
   { pluginUuid: uuid }: SampleGenericContentSidekickPluginProps,
@@ -41,7 +43,7 @@ function SampleGenericContentSidekickPlugin(
         section: 'Section 1',
         dataTest: 'section-1-generic-content-sidekick-abc',
         buttonIcon: {
-          svgContent: <BatteryIcon />
+          svgContent: <BatteryIcon />,
         },
         open: false,
         contentFunction: (element: HTMLElement) => {

--- a/src/extensible-areas/action-button-dropdown-item/component.ts
+++ b/src/extensible-areas/action-button-dropdown-item/component.ts
@@ -2,6 +2,7 @@ import { ActionButtonDropdownItemType } from './enums';
 import {
   ActionButtonDropdownInterface, ActionButtonDropdownOptionProps,
 } from './types';
+import { PluginIconType } from '../common/icon';
 
 // ActionButtonDropdown Extensible Area
 
@@ -12,7 +13,7 @@ export class ActionButtonDropdownOption implements ActionButtonDropdownInterface
 
   label: string;
 
-  icon: string;
+  icon: PluginIconType;
 
   tooltip: string;
 

--- a/src/extensible-areas/action-button-dropdown-item/types.ts
+++ b/src/extensible-areas/action-button-dropdown-item/types.ts
@@ -1,15 +1,16 @@
 import { PluginProvidedUiItemDescriptor } from '../base';
+import { PluginIconType } from '../common/icon';
 
 /**
  * Interface for a generic item for the action button dropdown.
  */
-export interface ActionButtonDropdownInterface extends PluginProvidedUiItemDescriptor{
+export interface ActionButtonDropdownInterface extends PluginProvidedUiItemDescriptor {
 }
 
 export interface ActionButtonDropdownOptionProps {
   id?: string;
   label: string;
-  icon: string;
+  icon: PluginIconType;
   tooltip: string;
   dataTest?: string;
   allowed: boolean;

--- a/src/extensible-areas/actions-bar-item/component.ts
+++ b/src/extensible-areas/actions-bar-item/component.ts
@@ -9,8 +9,8 @@ import {
   SelectOption,
   ToggleGroupOption,
   ActionsBarToggleGroupProps,
-  ActionsBarIconType,
 } from './types';
+import { PluginIconType } from '../common/icon';
 
 // ActionsBar Extensible Area
 
@@ -34,13 +34,13 @@ class ActionsBarItem implements ActionsBarInterface {
     this.dataTest = dataTest;
   }
 
-  setItemId(id: string):void {
+  setItemId(id: string): void {
     this.id = `ActionsBar${this.type}_${id}`;
   }
 }
 
 export class ActionsBarButton extends ActionsBarItem {
-  icon: ActionsBarIconType;
+  icon: PluginIconType;
 
   tooltip: string;
 
@@ -63,7 +63,7 @@ export class ActionsBarButton extends ActionsBarItem {
    * @returns Object that will be interpreted by the core of Bigbluebutton (HTML5)
    */
   constructor({
-    id, icon, tooltip = '', dataTest = '', onClick = () => {}, position = ActionsBarPosition.RIGHT,
+    id, icon, tooltip = '', dataTest = '', onClick = () => { }, position = ActionsBarPosition.RIGHT,
     color = 'primary',
   }: ActionsBarButtonProps) {
     super({
@@ -78,7 +78,7 @@ export class ActionsBarButton extends ActionsBarItem {
 }
 
 export class ActionsBarSeparator extends ActionsBarItem {
-  icon: string;
+  icon: PluginIconType;
 
   /**
    * Returns object to be used in the setter for action bar. In this case,
@@ -134,7 +134,7 @@ export class ActionsBarSelector extends ActionsBarItem {
     options = [],
     defaultOption = options[0],
     dataTest = '',
-    onChange = () => {},
+    onChange = () => { },
     position = ActionsBarPosition.RIGHT,
     width = 140,
   }: ActionsBarSelectorProps) {
@@ -184,7 +184,7 @@ export class ActionsBarToggleGroup extends ActionsBarItem {
     options = [],
     defaultOption = options[0],
     dataTest = '',
-    onChange = () => {},
+    onChange = () => { },
     position = ActionsBarPosition.RIGHT,
   }: ActionsBarToggleGroupProps) {
     super({

--- a/src/extensible-areas/actions-bar-item/types.ts
+++ b/src/extensible-areas/actions-bar-item/types.ts
@@ -1,6 +1,7 @@
 import { ChangeEvent, MouseEvent } from 'react';
 import { PluginProvidedUiItemDescriptor } from '../base';
 import { ActionsBarItemType, ActionsBarPosition } from './enums';
+import { PluginIconType } from '../common/icon';
 
 /**
  * Interface for the generic Actions bar item. (`position` is mandatory)
@@ -16,22 +17,9 @@ export interface ActionsBarItemProps {
   dataTest?: string;
 }
 
-export interface ActionsBarButtonIconSvg {
-  svgContent: React.SVGProps<SVGSVGElement>;
-}
-
-export interface ActionsBarButtonIconName {
-  /**
-   * Default icon name defined by BBB (see options there).
-   */
-  iconName: string;
-}
-
-export type ActionsBarIconType = ActionsBarButtonIconSvg | ActionsBarButtonIconName
-
 export interface ActionsBarButtonProps {
   id?: string;
-  icon: ActionsBarIconType;
+  icon: PluginIconType;
   tooltip: string;
   position: ActionsBarPosition;
   dataTest?: string;
@@ -41,7 +29,7 @@ export interface ActionsBarButtonProps {
 
 export interface ActionsBarSeparatorProps {
   position: ActionsBarPosition;
-  icon?: string;
+  icon?: PluginIconType;
   dataTest?: string;
 }
 

--- a/src/extensible-areas/audio-settings-dropdown-item/component.ts
+++ b/src/extensible-areas/audio-settings-dropdown-item/component.ts
@@ -2,6 +2,7 @@ import { AudioSettingsDropdownItemType } from './enums';
 import {
   AudioSettingsDropdownInterface, AudioSettingsDropdownOptionProps,
 } from './types';
+import { PluginIconType } from '../common/icon';
 
 // AudioSettingsDropdown Extensible Area
 
@@ -12,7 +13,7 @@ export class AudioSettingsDropdownOption implements AudioSettingsDropdownInterfa
 
   label: string;
 
-  icon: string;
+  icon: PluginIconType;
 
   dataTest: string;
 

--- a/src/extensible-areas/audio-settings-dropdown-item/types.ts
+++ b/src/extensible-areas/audio-settings-dropdown-item/types.ts
@@ -1,4 +1,5 @@
 import { PluginProvidedUiItemDescriptor } from '../base';
+import { PluginIconType } from '../common/icon';
 
 /**
  * Audio Settings Dropdown Item - The general Audio settings extensible area
@@ -7,13 +8,13 @@ import { PluginProvidedUiItemDescriptor } from '../base';
  * To make this dropdown appear, the user needs to enter with audio, either listen only
  * or microphone. This will make a small downward arrow appear (chevron).
  */
-export interface AudioSettingsDropdownInterface extends PluginProvidedUiItemDescriptor{
+export interface AudioSettingsDropdownInterface extends PluginProvidedUiItemDescriptor {
 }
 
 export interface AudioSettingsDropdownOptionProps {
   id?: string;
   label: string;
-  icon: string;
+  icon: PluginIconType;
   dataTest?: string;
   onClick: () => void;
 }

--- a/src/extensible-areas/camera-settings-dropdown-item/component.ts
+++ b/src/extensible-areas/camera-settings-dropdown-item/component.ts
@@ -2,6 +2,7 @@ import { CameraSettingsDropdownItemType } from './enums';
 import {
   CameraSettingsDropdownInterface, CameraSettingsDropdownOptionProps,
 } from './types';
+import { PluginIconType } from '../common/icon';
 
 // CameraSettingsDropdown Extensible Area
 
@@ -12,7 +13,7 @@ export class CameraSettingsDropdownOption implements CameraSettingsDropdownInter
 
   label: string;
 
-  icon: string;
+  icon: PluginIconType;
 
   dataTest: string = '';
 
@@ -30,7 +31,7 @@ export class CameraSettingsDropdownOption implements CameraSettingsDropdownInter
    * @returns Object that will be interpreted by the core of Bigbluebutton (HTML5).
    */
   constructor({
-    id, label = '', icon = '', dataTest = '', onClick = () => {},
+    id, label = '', icon = '', dataTest = '', onClick = () => { },
   }: CameraSettingsDropdownOptionProps) {
     if (id) {
       this.id = id;

--- a/src/extensible-areas/camera-settings-dropdown-item/types.ts
+++ b/src/extensible-areas/camera-settings-dropdown-item/types.ts
@@ -1,4 +1,5 @@
 import { PluginProvidedUiItemDescriptor } from '../base';
+import { PluginIconType } from '../common/icon';
 
 /**
  * Camera Settings Dropdown Item - The general Camera settings extensible area
@@ -7,13 +8,13 @@ import { PluginProvidedUiItemDescriptor } from '../base';
  * To make this dropdown appear, the user needs to enter with webcam.
  * This will make a small downward arrow appear in the camera icon (the chevron).
  */
-export interface CameraSettingsDropdownInterface extends PluginProvidedUiItemDescriptor{
+export interface CameraSettingsDropdownInterface extends PluginProvidedUiItemDescriptor {
 }
 
 export interface CameraSettingsDropdownOptionProps {
   id?: string;
   label: string;
-  icon: string;
+  icon: PluginIconType;
   dataTest?: string;
   onClick: () => void;
 }

--- a/src/extensible-areas/common/icon/index.ts
+++ b/src/extensible-areas/common/icon/index.ts
@@ -1,0 +1,1 @@
+export * from './types';

--- a/src/extensible-areas/common/icon/types.ts
+++ b/src/extensible-areas/common/icon/types.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 export interface PluginIconName {
   iconName: string;

--- a/src/extensible-areas/common/icon/types.ts
+++ b/src/extensible-areas/common/icon/types.ts
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export interface PluginIconName {
+  iconName: string;
+}
+
+export interface PluginIconSvgContent {
+  svgContent: React.SVGProps<SVGSVGElement>;
+}
+
+export type PluginIconType = string | PluginIconName | PluginIconSvgContent;

--- a/src/extensible-areas/common/index.ts
+++ b/src/extensible-areas/common/index.ts
@@ -1,0 +1,1 @@
+export * from './icon';

--- a/src/extensible-areas/generic-content-item/component.ts
+++ b/src/extensible-areas/generic-content-item/component.ts
@@ -1,6 +1,7 @@
 import * as ReactDOM from 'react-dom/client';
 import { GenericContentType } from './enums';
 import { GenericContentInterface, GenericContentMainAreaProps, GenericContentSidekickAreaProps } from './types';
+import { PluginIconType } from '../common/icon';
 
 // GenericContent Extensible Area
 
@@ -48,7 +49,7 @@ export class GenericContentSidekickArea implements GenericContentInterface {
 
   section: string = '';
 
-  buttonIcon: string = '';
+  buttonIcon: PluginIconType = '';
 
   open: boolean = false;
 

--- a/src/extensible-areas/generic-content-item/types.ts
+++ b/src/extensible-areas/generic-content-item/types.ts
@@ -1,5 +1,6 @@
 import * as ReactDOM from 'react-dom/client';
 import { PluginProvidedUiItemDescriptor } from '../base';
+import { PluginIconType } from '../common/icon';
 
 export interface GenericContentInterface extends PluginProvidedUiItemDescriptor {
 }
@@ -15,7 +16,7 @@ export interface GenericContentSidekickAreaProps {
   contentFunction: (element: HTMLElement) => ReactDOM.Root;
   name: string;
   section: string;
-  buttonIcon: string;
+  buttonIcon: PluginIconType;
   open: boolean;
   dataTest?: string;
 }

--- a/src/extensible-areas/index.ts
+++ b/src/extensible-areas/index.ts
@@ -1,3 +1,4 @@
+export * from './common/icon';
 export * from './presentation-toolbar-item';
 export * from './user-list-dropdown-item';
 export * from './action-button-dropdown-item';

--- a/src/extensible-areas/nav-bar-item/component.ts
+++ b/src/extensible-areas/nav-bar-item/component.ts
@@ -3,6 +3,7 @@ import {
   NavBarInterface, NavBarButtonProps,
   NavBarInfoProps,
 } from './types';
+import { PluginIconType } from '../common/icon';
 
 // NavBar Extensible Area
 
@@ -13,7 +14,7 @@ export class NavBarButton implements NavBarInterface {
 
   label: string;
 
-  icon: string;
+  icon: PluginIconType;
 
   tooltip: string;
 
@@ -45,7 +46,7 @@ export class NavBarButton implements NavBarInterface {
    * @returns Object that will be interpreted by the core of Bigbluebutton (HTML5).
    */
   constructor({
-    id, label = '', icon = '', tooltip = '', disabled = true, dataTest = '', onClick = () => {},
+    id, label = '', icon = '', tooltip = '', disabled = true, dataTest = '', onClick = () => { },
     position = NavBarItemPosition.RIGHT, hasSeparator = true,
   }: NavBarButtonProps) {
     if (id) {

--- a/src/extensible-areas/nav-bar-item/types.ts
+++ b/src/extensible-areas/nav-bar-item/types.ts
@@ -1,7 +1,8 @@
 import { PluginProvidedUiItemDescriptor } from '../base';
 import { NavBarItemPosition } from './enums';
+import { PluginIconType } from '../common/icon';
 
-export interface NavBarInterface extends PluginProvidedUiItemDescriptor{
+export interface NavBarInterface extends PluginProvidedUiItemDescriptor {
   position: NavBarItemPosition;
   hasSeparator: boolean;
 }
@@ -9,7 +10,7 @@ export interface NavBarInterface extends PluginProvidedUiItemDescriptor{
 export interface NavBarButtonProps {
   id?: string;
   label: string;
-  icon: string;
+  icon: PluginIconType;
   tooltip: string;
   disabled: boolean;
   hasSeparator: boolean;

--- a/src/extensible-areas/options-dropdown-item/component.ts
+++ b/src/extensible-areas/options-dropdown-item/component.ts
@@ -2,6 +2,7 @@ import { OptionsDropdownItemType } from './enums';
 import {
   OptionsDropdownInterface, OptionsDropdownOptionProps,
 } from './types';
+import { PluginIconType } from '../common/icon';
 
 // OptionsDropdown Extensible Area
 
@@ -12,7 +13,7 @@ export class OptionsDropdownOption implements OptionsDropdownInterface {
 
   label: string;
 
-  icon: string;
+  icon: PluginIconType;
 
   dataTest: string;
 
@@ -30,7 +31,7 @@ export class OptionsDropdownOption implements OptionsDropdownInterface {
    * @returns Object that will be interpreted by the core of Bigbluebutton (HTML5).
    */
   constructor({
-    id, label = '', icon = '', dataTest = '', onClick = () => {},
+    id, label = '', icon = '', dataTest = '', onClick = () => { },
   }: OptionsDropdownOptionProps) {
     if (id) {
       this.id = id;

--- a/src/extensible-areas/options-dropdown-item/types.ts
+++ b/src/extensible-areas/options-dropdown-item/types.ts
@@ -1,4 +1,5 @@
 import { PluginProvidedUiItemDescriptor } from '../base';
+import { PluginIconType } from '../common/icon';
 
 /**
  * Options Dropdown Item - The general options dropdown extensible area item
@@ -7,13 +8,13 @@ import { PluginProvidedUiItemDescriptor } from '../base';
  * This dropdown is related to the options menu on the top right corner of the UI
  * (the 3 dots)
  */
-export interface OptionsDropdownInterface extends PluginProvidedUiItemDescriptor{
+export interface OptionsDropdownInterface extends PluginProvidedUiItemDescriptor {
 }
 
 export interface OptionsDropdownOptionProps {
   id?: string;
   label: string;
-  icon: string;
+  icon: PluginIconType;
   onClick: () => void;
   dataTest?: string;
 }

--- a/src/extensible-areas/presentation-dropdown-item/component.ts
+++ b/src/extensible-areas/presentation-dropdown-item/component.ts
@@ -2,6 +2,7 @@ import { PresentationDropdownItemType } from './enums';
 import {
   PresentationDropdownInterface, PresentationDropdownOptionProps,
 } from './types';
+import { PluginIconType } from '../common/icon';
 
 // PresentationDropdown Extensible Area
 
@@ -12,7 +13,7 @@ export class PresentationDropdownOption implements PresentationDropdownInterface
 
   label: string;
 
-  icon: string;
+  icon: PluginIconType;
 
   dataTest: string;
 
@@ -31,7 +32,7 @@ export class PresentationDropdownOption implements PresentationDropdownInterface
    * @returns Object that will be interpreted by the core of Bigbluebutton (HTML5).
    */
   constructor({
-    id, label = '', icon = '', dataTest = '', onClick = () => {},
+    id, label = '', icon = '', dataTest = '', onClick = () => { },
   }: PresentationDropdownOptionProps) {
     if (id) {
       this.id = id;

--- a/src/extensible-areas/presentation-dropdown-item/types.ts
+++ b/src/extensible-areas/presentation-dropdown-item/types.ts
@@ -1,4 +1,5 @@
 import { PluginProvidedUiItemDescriptor } from '../base';
+import { PluginIconType } from '../common/icon';
 
 /**
  * Presentation Dropdown Item - The general presentation dropdown extensible area item
@@ -7,13 +8,13 @@ import { PluginProvidedUiItemDescriptor } from '../base';
  * This dropdown is located when clicking the three dots on the top left corner
  * of the presentation area.
  */
-export interface PresentationDropdownInterface extends PluginProvidedUiItemDescriptor{
+export interface PresentationDropdownInterface extends PluginProvidedUiItemDescriptor {
 }
 
 export interface PresentationDropdownOptionProps {
   id?: string;
   label: string;
-  icon: string;
+  icon: PluginIconType;
   onClick: () => void;
   dataTest?: string;
 }

--- a/src/extensible-areas/screenshare-helper-item/component.ts
+++ b/src/extensible-areas/screenshare-helper-item/component.ts
@@ -4,6 +4,7 @@ import {
   ScreenshareHelperButtonInterface,
   ScreenshareHelperButtonOnclickCallback,
 } from './types';
+import { PluginIconType } from '../common/icon';
 
 // ScreenshareHelper Extensible Area
 
@@ -14,7 +15,7 @@ export class ScreenshareHelperButton implements ScreenshareHelperButtonInterface
 
   label: string;
 
-  icon: string;
+  icon: PluginIconType;
 
   tooltip: string;
 
@@ -44,7 +45,7 @@ export class ScreenshareHelperButton implements ScreenshareHelperButtonInterface
    * @returns Object that will be interpreted by the core of Bigbluebutton (HTML5).
    */
   constructor({
-    id, label = '', icon = '', tooltip = '', disabled = true, dataTest = '', onClick = () => {},
+    id, label = '', icon = '', tooltip = '', disabled = true, dataTest = '', onClick = () => { },
     position = ScreenshareHelperItemPosition.TOP_RIGHT,
   }: ScreenshareHelperButtonProps) {
     if (id) {

--- a/src/extensible-areas/screenshare-helper-item/types.ts
+++ b/src/extensible-areas/screenshare-helper-item/types.ts
@@ -1,7 +1,8 @@
 import { PluginProvidedUiItemDescriptor } from '../base';
 import { ScreenshareHelperItemPosition } from './enums';
+import { PluginIconType } from '../common/icon';
 
-export interface ScreenshareHelperInterface extends PluginProvidedUiItemDescriptor{
+export interface ScreenshareHelperInterface extends PluginProvidedUiItemDescriptor {
   position: ScreenshareHelperItemPosition;
 }
 
@@ -9,10 +10,10 @@ export interface ScreenshareHelperButtonOnclickCallback {
   browserClickEvent: React.MouseEvent<HTMLElement>;
 }
 
-export interface ScreenshareHelperButtonInterface extends ScreenshareHelperInterface{
+export interface ScreenshareHelperButtonInterface extends ScreenshareHelperInterface {
   label: string;
 
-  icon: string;
+  icon: PluginIconType;
 
   tooltip: string;
 
@@ -26,7 +27,7 @@ export interface ScreenshareHelperButtonInterface extends ScreenshareHelperInter
 export interface ScreenshareHelperButtonProps {
   id?: string;
   label?: string;
-  icon: string;
+  icon: PluginIconType;
   tooltip: string;
   disabled: boolean;
   hasSeparator: boolean;

--- a/src/extensible-areas/user-camera-dropdown-item/component.ts
+++ b/src/extensible-areas/user-camera-dropdown-item/component.ts
@@ -5,6 +5,7 @@ import {
   UserCameraDropdownInterface, UserCameraDropdownOptionProps,
   UserCameraDropdownSeparatorProps,
 } from './types';
+import { PluginIconType } from '../common/icon';
 
 // UserCameraDropdown Extensible Area
 
@@ -15,7 +16,7 @@ export class UserCameraDropdownOption implements UserCameraDropdownInterface {
 
   label: string;
 
-  icon: string;
+  icon: PluginIconType;
 
   dataTest: string;
 
@@ -35,7 +36,7 @@ export class UserCameraDropdownOption implements UserCameraDropdownInterface {
    * @returns Object that will be interpreted by the core of Bigbluebutton (HTML5)
    */
   constructor({
-    id, label = '', icon = '', dataTest = '', onClick = () => {},
+    id, label = '', icon = '', dataTest = '', onClick = () => { },
     displayFunction = () => true,
   }: UserCameraDropdownOptionProps) {
     if (id) {

--- a/src/extensible-areas/user-camera-dropdown-item/types.ts
+++ b/src/extensible-areas/user-camera-dropdown-item/types.ts
@@ -1,4 +1,5 @@
 import { PluginProvidedUiItemDescriptor } from '../base';
+import { PluginIconType } from '../common/icon';
 
 export interface UserCameraDropdownCallbackFunctionsArguments {
   streamId: string;
@@ -6,7 +7,7 @@ export interface UserCameraDropdownCallbackFunctionsArguments {
 }
 
 export interface OnclickFunctionCallbackArguments
-  extends UserCameraDropdownCallbackFunctionsArguments{
+  extends UserCameraDropdownCallbackFunctionsArguments {
   browserClickEvent: React.MouseEvent<HTMLElement>;
 }
 
@@ -16,7 +17,7 @@ export interface OnclickFunctionCallbackArguments
  * @remarks
  * This dropdown is located on the bottom left corner of the user webcam area
  */
-export interface UserCameraDropdownInterface extends PluginProvidedUiItemDescriptor{
+export interface UserCameraDropdownInterface extends PluginProvidedUiItemDescriptor {
   displayFunction?: (args: UserCameraDropdownCallbackFunctionsArguments) => boolean;
 }
 
@@ -28,7 +29,7 @@ export interface UserCameraDropdownSeparatorProps {
 export interface UserCameraDropdownOptionProps {
   id?: string;
   label: string;
-  icon: string;
+  icon: PluginIconType;
   onClick: (args: OnclickFunctionCallbackArguments) => void;
   displayFunction?: (args: UserCameraDropdownCallbackFunctionsArguments) => boolean;
   dataTest?: string;

--- a/src/extensible-areas/user-camera-helper-item/component.ts
+++ b/src/extensible-areas/user-camera-helper-item/component.ts
@@ -5,6 +5,7 @@ import {
   UserCameraHelperButtonOnclickCallback,
   UserCameraHelperCallbackFunctionArguments,
 } from './types';
+import { PluginIconType } from '../common/icon';
 
 // UserCameraHelper Extensible Area
 
@@ -17,7 +18,7 @@ export class UserCameraHelperButton implements UserCameraHelperButtonInterface {
 
   displayFunction?: (args: UserCameraHelperCallbackFunctionArguments) => boolean;
 
-  icon: string;
+  icon: PluginIconType;
 
   tooltip: string;
 
@@ -47,7 +48,7 @@ export class UserCameraHelperButton implements UserCameraHelperButtonInterface {
    * @returns Object that will be interpreted by the core of Bigbluebutton (HTML5).
    */
   constructor({
-    id, label = '', icon = '', tooltip = '', disabled = true, dataTest = '', onClick = () => {},
+    id, label = '', icon = '', tooltip = '', disabled = true, dataTest = '', onClick = () => { },
     position = UserCameraHelperItemPosition.TOP_RIGHT, displayFunction,
   }: UserCameraHelperButtonProps) {
     if (id) {

--- a/src/extensible-areas/user-camera-helper-item/types.ts
+++ b/src/extensible-areas/user-camera-helper-item/types.ts
@@ -1,7 +1,8 @@
 import { PluginProvidedUiItemDescriptor } from '../base';
 import { UserCameraHelperItemPosition } from './enums';
+import { PluginIconType } from '../common/icon';
 
-export interface UserCameraHelperInterface extends PluginProvidedUiItemDescriptor{
+export interface UserCameraHelperInterface extends PluginProvidedUiItemDescriptor {
   position: UserCameraHelperItemPosition;
 }
 
@@ -16,10 +17,10 @@ export interface UserCameraHelperCallbackFunctionArguments {
   userId: string;
 }
 
-export interface UserCameraHelperButtonInterface extends UserCameraHelperInterface{
+export interface UserCameraHelperButtonInterface extends UserCameraHelperInterface {
   label: string;
 
-  icon: string;
+  icon: PluginIconType;
 
   tooltip: string;
 
@@ -35,7 +36,7 @@ export interface UserCameraHelperButtonInterface extends UserCameraHelperInterfa
 export interface UserCameraHelperButtonProps {
   id?: string;
   label?: string;
-  icon: string;
+  icon: PluginIconType;
   tooltip: string;
   disabled: boolean;
   displayFunction?: (args: UserCameraHelperCallbackFunctionArguments) => boolean;

--- a/src/extensible-areas/user-list-dropdown-item/component.ts
+++ b/src/extensible-areas/user-list-dropdown-item/component.ts
@@ -155,8 +155,7 @@ export class UserListDropdownFixedContentInformation implements UserListDropdown
   };
 }
 
-export class UserListDropdownGenericContentInformation
-  implements UserListDropdownInterface {
+export class UserListDropdownGenericContentInformation implements UserListDropdownInterface {
   id: string = '';
 
   userId: string;

--- a/src/extensible-areas/user-list-dropdown-item/component.ts
+++ b/src/extensible-areas/user-list-dropdown-item/component.ts
@@ -7,6 +7,7 @@ import {
   UserListDropdownGenericContentInformationProps,
 } from './types';
 import { UserListDropdownItemType, UserListDropdownSeparatorPosition } from './enums';
+import { PluginIconType } from '../common/icon';
 
 // UserListDropdown Extensible Area
 
@@ -19,7 +20,7 @@ export class UserListDropdownOption implements UserListDropdownInterface {
 
   label: string;
 
-  icon: string;
+  icon: PluginIconType;
 
   tooltip: string;
 
@@ -45,7 +46,7 @@ export class UserListDropdownOption implements UserListDropdownInterface {
    * @returns Object that will be interpreted by the core of Bigbluebutton (HTML5).
    */
   constructor({
-    label = '', icon = '', tooltip = '', allowed = true, dataTest = '', onClick = () => {},
+    label = '', icon = '', tooltip = '', allowed = true, dataTest = '', onClick = () => { },
     userId = '',
   }: UserListDropdownOptionProps) {
     this.userId = userId;
@@ -105,9 +106,9 @@ export class UserListDropdownFixedContentInformation implements UserListDropdown
 
   label: string;
 
-  icon: string;
+  icon: PluginIconType;
 
-  iconRight: string;
+  iconRight: PluginIconType;
 
   textColor: string;
 
@@ -155,7 +156,7 @@ export class UserListDropdownFixedContentInformation implements UserListDropdown
 }
 
 export class UserListDropdownGenericContentInformation
-implements UserListDropdownInterface {
+  implements UserListDropdownInterface {
   id: string = '';
 
   userId: string;
@@ -211,7 +212,7 @@ export class UserListDropdownTitleAction implements UserListDropdownInterface {
 
   type: UserListDropdownItemType;
 
-  icon: string;
+  icon: PluginIconType;
 
   tooltip: string;
 

--- a/src/extensible-areas/user-list-dropdown-item/types.ts
+++ b/src/extensible-areas/user-list-dropdown-item/types.ts
@@ -1,5 +1,6 @@
 import { PluginProvidedUiItemDescriptor } from '../base';
 import { UserListDropdownSeparatorPosition } from './enums';
+import { PluginIconType } from '../common/icon';
 
 /**
  * User List Dropdown Item - The general user list dropdown extensible area item
@@ -8,13 +9,13 @@ import { UserListDropdownSeparatorPosition } from './enums';
  * This dropdown is located on the bottom left corner of the user webcam area.
  * Mandatory to have the `userId`
  */
-export interface UserListDropdownInterface extends PluginProvidedUiItemDescriptor{
+export interface UserListDropdownInterface extends PluginProvidedUiItemDescriptor {
   userId: string;
 }
 
 export interface UserListDropdownOptionProps {
   label: string;
-  icon: string;
+  icon: PluginIconType;
   tooltip: string;
   allowed: boolean;
   userId: string;
@@ -39,8 +40,8 @@ export interface UserListDropdownGenericContentInformationProps {
 export interface UserListDropdownFixedContentInformationProps {
   id?: string;
   label: string;
-  icon?: string;
-  iconRight?: string;
+  icon?: PluginIconType;
+  iconRight?: PluginIconType;
   allowed: boolean;
   userId: string;
   textColor: string;
@@ -54,7 +55,7 @@ export interface UserListDropdownTitleActionOnClickArguments {
 export interface UserListDropdownTitleActionProps {
   id?: string;
   tooltip: string;
-  icon: string;
+  icon: PluginIconType;
   userId: string;
   onClick: (args: UserListDropdownTitleActionOnClickArguments) => void;
   dataTest?: string;

--- a/src/extensible-areas/user-list-item-additional-information/component.ts
+++ b/src/extensible-areas/user-list-item-additional-information/component.ts
@@ -3,6 +3,7 @@ import {
   UserListItemAdditionalInformationInterface, UserListItemIconProps,
   UserListItemLabelProps,
 } from './types';
+import { PluginIconType } from '../common/icon';
 
 // UserListItemAdditionalInformation Extensible Area
 
@@ -13,7 +14,7 @@ export class UserListItemIcon implements UserListItemAdditionalInformationInterf
 
   userId: string;
 
-  icon: string;
+  icon: PluginIconType;
 
   dataTest: string;
 
@@ -53,7 +54,7 @@ export class UserListItemLabel implements UserListItemAdditionalInformationInter
 
   userId: string;
 
-  icon: string;
+  icon: PluginIconType;
 
   label: string;
 

--- a/src/extensible-areas/user-list-item-additional-information/types.ts
+++ b/src/extensible-areas/user-list-item-additional-information/types.ts
@@ -1,4 +1,5 @@
 import { PluginProvidedUiItemDescriptor } from '../base';
+import { PluginIconType } from '../common/icon';
 
 /**
  * User List Item Additional Information - The general user list item additional information item
@@ -14,14 +15,14 @@ export interface UserListItemAdditionalInformationInterface extends PluginProvid
 export interface UserListItemIconProps {
   id?: string;
   userId: string;
-  icon: string;
+  icon: PluginIconType;
   dataTest?: string;
 }
 
 export interface UserListItemLabelProps {
   id?: string;
   userId: string;
-  icon: string;
+  icon: PluginIconType;
   label: string;
   dataTest?: string;
 }

--- a/src/ui-commands/notification/types.ts
+++ b/src/ui-commands/notification/types.ts
@@ -1,4 +1,5 @@
 import { NotificationTypeUiCommand } from './enums';
+import { PluginIconType } from '../../extensible-areas/common/icon';
 
 export interface SendNotificationCommandArgumentsOptions {
   helpLabel?: string,
@@ -8,7 +9,7 @@ export interface SendNotificationCommandArgumentsOptions {
 
 export interface SendNotificationCommandArguments {
   message: string;
-  icon: string;
+  icon: PluginIconType;
   type: NotificationTypeUiCommand;
   options?: SendNotificationCommandArgumentsOptions;
   content?: string;


### PR DESCRIPTION
### What does this PR do?

Adds custom SVG icon support across all plugin extensible areas. Every `icon` (and `iconRight`, `buttonIcon`) property now accepts `PluginIconType`. To guarantee backwards compatibility the definition of this type is:

```ts
export type PluginIconType = string | {
  svgContent: <svg>; // or
  iconName: string;
};
```

This is just pseudo-code, check the file `src/extensible-areas/common/icon/types.ts` for details.


### Closes Issue(s)

Closes #204

### Motivation

Plugin authors were limited to BBB's built-in icon font. This change allows any custom SVG to be used as an icon in any extensible area.

### More

**Extensible areas updated:** `actions-bar-item`, `nav-bar-item`, `action-button-dropdown-item`, `audio-settings-dropdown-item`, `camera-settings-dropdown-item`, `options-dropdown-item`, `presentation-dropdown-item`, `screenshare-helper-item`, `user-camera-dropdown-item`, `user-camera-helper-item`, `user-list-dropdown-item`, `user-list-item-additional-information`, `generic-content-item`.

**Result:**

<img width="1847" height="939" alt="demo_new_icon_svgContent" src="https://github.com/user-attachments/assets/4ee59aca-081b-4b21-8b12-239fce585e79" />

Sample: `generic-content-sidekick` plugin using a custom SVG as `buttonIcon`
