### PR TITLE
fix(auth): fall back to sessionStorage for session token (fixes getSessionToken() returning undefined on BBB 3.0.30+)

### DIFF
--- a/src/core/auxiliary/session-token/getter.ts
+++ b/src/core/auxiliary/session-token/getter.ts
@@ -1,4 +1,17 @@
 export function getSessionToken(): string | undefined {
-  const params = new URLSearchParams(window.location.search);
-  return params.get('sessionToken') || undefined;
+  // BigBlueButton 3.0.30 (bigbluebutton/bigbluebutton#25219, "Hide sessionToken
+  // from URL bar") removes `sessionToken` from window.location during client
+  // startup and stores it in sessionStorage under the key `BBB_sessionToken`
+  // (ObservableStorage 'BBB_' prefix + 'sessionToken'). Plugins mount after that
+  // bootstrap, so reading only the URL returns undefined on 3.0.30+.
+  //
+  // Read the URL first (older cores, and the brief window before the strip),
+  // then fall back to sessionStorage so the token resolves on 3.0.30+ too.
+  const fromUrl = new URLSearchParams(window.location.search).get('sessionToken');
+  if (fromUrl) return fromUrl;
+  try {
+    return window.sessionStorage.getItem('BBB_sessionToken') || undefined;
+  } catch {
+    return undefined;
+  }
 }


### PR DESCRIPTION
## Problem

`getSessionToken()` returns `undefined` on BigBlueButton **3.0.30+**, breaking any plugin that uses it to authenticate a connection.

BBB 3.0.30 (bigbluebutton/bigbluebutton#25219, *"Hide sessionToken from URL bar"*) removes `sessionToken` from `window.location` during client bootstrap (`history.replaceState`) and stores it in `window.sessionStorage` under `BBB_sessionToken`. Plugins mount **after** that bootstrap, so the existing getter — which reads only the URL query string — finds nothing and returns `undefined`. The token is gone from the URL by the time any plugin runs.

That PR notes no plugin/SDK impact; the SDK's reliance on the URL wasn't considered. The getter is unchanged across all releases, so this affects every SDK version on a 3.0.30+ core, and bumping the SDK does not help.

See #268 for the full write-up.

## Fix

Read the token from the URL first (older cores, and the brief window before the strip), then fall back to `sessionStorage['BBB_sessionToken']` — exactly where the 3.0.30 client now stores it. Version-agnostic, with no behavior change on cores `< 3.0.30`. The `sessionStorage` access is wrapped in `try/catch` for environments where it isn't available.

```ts
const fromUrl = new URLSearchParams(window.location.search).get('sessionToken');
if (fromUrl) return fromUrl;
try {
  return window.sessionStorage.getItem('BBB_sessionToken') || undefined;
} catch {
  return undefined;
}
```

## Testing

Verified against the real-world failure that surfaced this: a remote-desktop plugin building `wss://host/vnc?sessionToken=${getSessionToken()}`.

- **3.0.30** (production): before, `GET /vnc?sessionToken=undefined` → `401`; with this change, the token resolves from `sessionStorage` and the connection authenticates (`101`).
- **3.0.29**: still works (token resolves; no regression).

## Note on `v0.1.x`

The same getter exists on the `v0.1.x` branch (BBB 3.1.x), where 3.0.30's URL change is also present, so it's affected too. Happy to open a matching PR there if you'd like — this PR targets `v0.0.x` since that's the 3.0.x line where the regression was observed.

---
*This PR was prepared by an AI assistant (Claude) on behalf of Brent Baccala (cosine@freesoft.org), based on diagnosing a production remote-desktop plugin failure on BBB 3.0.30 and verifying the fix on live 3.0.30 and 3.0.29 servers.*
