### PR TITLE
feat: New useTimer hook

### DIFF
--- a/src/core/api/BbbPluginSdk.ts
+++ b/src/core/api/BbbPluginSdk.ts
@@ -63,6 +63,8 @@ import { useCustomMutation } from '../../data-creation/hook';
 import { UseCustomMutationFunction } from '../../data-creation/types';
 import { UseMeetingDataFunction } from '../../data-consumption/domain/meeting/meeting-data/types';
 import { useMeetingData } from '../../data-consumption/domain/meeting/meeting-data/hooks';
+import { UseTimerFunction } from '../../data-consumption/domain/timer/types';
+import { useTimer } from '../../data-consumption/domain/timer/hooks';
 
 declare const window: PluginBrowserWindow;
 
@@ -108,6 +110,7 @@ export abstract class BbbPluginSdk {
     pluginApi.useMeetingData = useMeetingData as UseMeetingDataFunction;
     pluginApi.useUsersBasicInfo = (() => useUsersBasicInfo()) as UseUsersBasicInfoFunction;
     pluginApi.useTalkingIndicator = (() => useTalkingIndicator()) as UseTalkingIndicatorFunction;
+    pluginApi.useTimer = (() => useTimer()) as UseTimerFunction;
     pluginApi.getJoinUrl = (params) => getJoinUrl(params);
     pluginApi.useLoadedChatMessages = (
       () => useLoadedChatMessages()) as UseLoadedChatMessagesFunction;

--- a/src/core/api/types.ts
+++ b/src/core/api/types.ts
@@ -39,6 +39,7 @@ import { GetUiDataFunction } from '../../ui-data/getters/types';
 import { UseCustomQueryFunction } from '../../data-consumption/domain/shared/custom-query/types';
 import { UseCustomMutationFunction } from '../../data-creation/types';
 import { UseMeetingDataFunction } from '../../data-consumption/domain/meeting/meeting-data/types';
+import { UseTimerFunction } from '../../data-consumption/domain/timer/types';
 
 // Setter Functions for the API
 export type SetPresentationToolbarItems = (presentationToolbarItem:
@@ -195,6 +196,13 @@ export interface PluginApi {
    *
    */
   useTalkingIndicator?: UseTalkingIndicatorFunction;
+  /**
+   * Returns an object containing the current state of the meeting timer.
+   *
+   * @returns `GraphqlResponseWrapper` with the TimerData type.
+   *
+   */
+  useTimer?: UseTimerFunction;
   /**
    * Returns a boolean telling if the plugin should be unmounted or not based on the mounting
    * of the meeting. This means that if the meeting end or the user is ejected, this will

--- a/src/data-consumption/domain/timer/hooks.ts
+++ b/src/data-consumption/domain/timer/hooks.ts
@@ -1,0 +1,7 @@
+import { DataConsumptionHooks } from '../../enums';
+import { createDataConsumptionHook } from '../../factory/hookCreator';
+import { TimerData } from './types';
+
+export const useTimer = () => createDataConsumptionHook<TimerData>(
+  DataConsumptionHooks.TIMER,
+);

--- a/src/data-consumption/domain/timer/index.ts
+++ b/src/data-consumption/domain/timer/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './hooks';

--- a/src/data-consumption/domain/timer/types.ts
+++ b/src/data-consumption/domain/timer/types.ts
@@ -1,0 +1,15 @@
+import { GraphqlResponseWrapper } from '../../../core';
+
+export interface TimerData {
+  accumulated: number;
+  active: boolean;
+  songTrack: string;
+  time: number;
+  stopwatch: boolean;
+  running: boolean;
+  startedAt: string | null;
+  elapsed: boolean;
+  timePassed: number;
+}
+
+export type UseTimerFunction = () => GraphqlResponseWrapper<TimerData>;

--- a/src/data-consumption/enums.ts
+++ b/src/data-consumption/enums.ts
@@ -9,4 +9,5 @@ export enum DataConsumptionHooks {
   TALKING_INDICATOR = 'Hooks::UseTalkingIndicator',
   CUSTOM_SUBSCRIPTION = 'Hooks::CustomSubscription',
   CUSTOM_QUERY = 'Hooks::CustomQuery',
+  TIMER = 'Hooks::UseTimer',
 }

--- a/src/data-consumption/index.ts
+++ b/src/data-consumption/index.ts
@@ -4,5 +4,6 @@ export * from './domain/meeting';
 export * from './domain/users';
 export * from './domain/user-voice';
 export * from './domain/shared';
+export * from './domain/timer';
 
 export * from './factory/types';


### PR DESCRIPTION
### What does this PR do?

It creates a new hook `useTimer` that mirrors the same hook from the core html5 client functions. 


### Motivation

This will resolve [this comment](https://github.com/bigbluebutton/bigbluebutton/issues/18595#issuecomment-4536527343) and therefore we'll be able to make the suggestion in the issue as a Plugin.

### More

This PR is closely related with the PR in the core: https://github.com/bigbluebutton/bigbluebutton/pull/25335
