### PR TITLE
fix: getRemoteData using getSessionToken

### DIFF
--- a/src/remote-data/utils.ts
+++ b/src/remote-data/utils.ts
@@ -1,6 +1,8 @@
+import { getSessionToken } from '../core/auxiliary/session-token/getter';
+
 export const getRemoteData = (dataSourceName: string, pluginName: string) => fetch(`/api/plugin/${pluginName}/${dataSourceName}/`, {
   credentials: 'include',
   headers: {
-    'x-session-token': new URLSearchParams(window.location.search).get('sessionToken') ?? '',
+    'x-session-token': getSessionToken() ?? '',
   },
 });


### PR DESCRIPTION
### What does this PR do?

It makes the function getRemoteData use the getSessionToken function which works to get the session token for both ways:

- Current way: from the session storage;
- Previous way: as a URL query parameter;

### More

Given the importance of this fix, it would require a merge 0.0.x -> 0.1.x right after the merge of this PR.

I did a quick scan through the code, and it seems there's no other place trying to get the session token in the previous way, but if anyone should find some, please let me know and we fix it in this PR by using the utility/getter function `getSessionToken` which is already fixed.
