### PR TITLE
feat: add senderRole to useLoadedChatMessages

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,7 +576,7 @@ So we have the `data`, which is different for each hook, that's why it's a gener
     if (chatMessages) {
       pluginLogger.info('Total messages:', chatMessages.length);
       chatMessages.forEach((msg) => {
-        pluginLogger.info(`Message from ${msg.senderName}: ${msg.message}`);
+        pluginLogger.info(`Message from ${msg.senderUserId} (${msg.senderRole}): ${msg.message}`);
       });
     }
   }, [chatMessages]);

--- a/src/data-consumption/domain/chat/loaded-chat-messages/types.ts
+++ b/src/data-consumption/domain/chat/loaded-chat-messages/types.ts
@@ -5,6 +5,8 @@ export interface LoadedChatMessage {
   message: string;
   messageId: string;
   senderUserId: string;
+  // Static throughout the meeting; null for system messages
+  senderRole: string | null;
   messageMetadata: string;
 }
 


### PR DESCRIPTION
## Add `senderRole` to `useLoadedChatMessages`

Exposes the sender's role as it was at the moment the message was sent. Unlike the role available through `useUsersBasicInfo` / `useLoadedUserList`, this value is **static**: it does not change if the user is promoted/demoted later, and it survives the user leaving the meeting.

If you have suggestions for additional properties that should be included, feel free to leave a comment below.

This could be useful for addressing security concerns related to message authenticity. For example, if a user leaves the session and all we have is their userId (the previous scenario), we have no reliable way to determine whether a message was originally sent by a moderator.

### Changes

- `LoadedChatMessage` gains `senderRole: string | null`:

  ```ts
  export interface LoadedChatMessage {
    createdAt: string;
    message: string;
    messageId: string;
    senderUserId: string;
    // Static throughout the meeting; null for system messages
    senderRole: string | null;
    messageMetadata: string;
  }
  ```

- Fixed the chat example in the README, which referenced `msg.senderName` — a field that does not exist on `LoadedChatMessage`.

### Why nullable

`senderRole` is `null` for system messages (welcome message, moderator-only message, chat-cleared), which have no sender:

- `ChatMessageDAO.insertSystemMsg` inserts with `senderRole = None`
- `bbb_schema.sql` declares `"senderRole" varchar(20)` with no `NOT NULL`

These messages are returned by the same chat page query, so plugins will see them.

### More
PR Closely related: https://github.com/bigbluebutton/bigbluebutton/pull/25539